### PR TITLE
Fix for result 72

### DIFF
--- a/pyrisco/risco.py
+++ b/pyrisco/risco.py
@@ -251,6 +251,10 @@ class RiscoAPI:
 
         if "result" in json:
             if json["result"] == 72:
+                # Occasionally an empty response is returned with this result code.
+                # We don't know what it means but from what we can see the next
+                # request is always successful. By raising this exception we let
+                # the caller know that the request should be retried.
                 raise TemporaryError(str(json))
             elif json["result"] != 0:
                 raise OperationError(str(json))

--- a/pyrisco/risco.py
+++ b/pyrisco/risco.py
@@ -251,7 +251,7 @@ class RiscoAPI:
 
         if "result" in json:
             if json["result"] == 72:
-                raise MysteriousResultError(str(json))
+                raise TemporaryError(str(json))
             elif json["result"] != 0:
                 raise OperationError(str(json))
 
@@ -267,7 +267,7 @@ class RiscoAPI:
                     "sessionToken": self._session_id,
                 }
                 return await self._authenticated_post(site_url, site_body)
-            except MysteriousResultError as e:
+            except TemporaryError as e:
                 if i + 1 == NUM_RETRIES:
                     raise OperationError(e) from e
             except UnauthorizedError:
@@ -412,5 +412,5 @@ class OperationError(Exception):
     """Exception to indicate an error in operation."""
 
 
-class MysteriousResultError(Exception):
+class TemporaryError(Exception):
     """Exception to indicate an intermittent result of an unknown meaning."""


### PR DESCRIPTION
This is a fix (or workaround if you will) for the occasional unexpected response with result code 72.

It appears that after getting such response the next request is always successful, so this change should eliminate the issue entirely.