### PR TITLE
Add support for RP432MP panel

### DIFF
--- a/pyrisco/local/panels.py
+++ b/pyrisco/local/panels.py
@@ -48,14 +48,11 @@ def _rw432_capabilities(firmware):
   }
 
 def _rp432mp_capabilities(firmware):
-  max_zones = 512
-  max_outputs = 32
-
   return {
     PANEL_MODEL: 'LightSys+',
-    MAX_ZONES: max_zones,
+    MAX_ZONES: 512,
     MAX_PARTS: 32,
-    MAX_OUTPUTS: max_outputs,
+    MAX_OUTPUTS: 196,
   }
 
 

--- a/pyrisco/local/panels.py
+++ b/pyrisco/local/panels.py
@@ -47,6 +47,18 @@ def _rw432_capabilities(firmware):
     MAX_OUTPUTS: max_outputs,
   }
 
+def _rw432mp_capabilities(firmware):
+  max_zones = 512
+  max_outputs = 32
+
+  return {
+    PANEL_MODEL: 'LightSys+',
+    MAX_ZONES: max_zones,
+    MAX_PARTS: 32,
+    MAX_OUTPUTS: max_outputs,
+  }
+
+
 def _rw512_capabilities(firmware):
   max_zones = 64
   parts = list(map(int, firmware.split('.')))
@@ -69,6 +81,7 @@ PANELS = {
   'RW232': _rw232_capabilities,
   'RW332': _rw332_capabilities,
   'RP432': _rw432_capabilities,
+  'RP432MP': _rw432mp_capabilities,
   'RP512': _rw512_capabilities
 }
 

--- a/pyrisco/local/panels.py
+++ b/pyrisco/local/panels.py
@@ -47,7 +47,7 @@ def _rw432_capabilities(firmware):
     MAX_OUTPUTS: max_outputs,
   }
 
-def _rw432mp_capabilities(firmware):
+def _rp432mp_capabilities(firmware):
   max_zones = 512
   max_outputs = 32
 
@@ -81,7 +81,7 @@ PANELS = {
   'RW232': _rw232_capabilities,
   'RW332': _rw332_capabilities,
   'RP432': _rw432_capabilities,
-  'RP432MP': _rw432mp_capabilities,
+  'RP432MP': _rp432mp_capabilities,
   'RP512': _rw512_capabilities
 }
 

--- a/pyrisco/local/risco_socket.py
+++ b/pyrisco/local/risco_socket.py
@@ -33,10 +33,7 @@ class RiscoSocket:
       self._queue = asyncio.Queue()
       self._listen_task = asyncio.create_task(self._listen())
       self._crypt = RiscoCrypt(self._encoding)
-      try:
-        panel_id = int(await self.send_result_command('RID'))
-      except ValueError:
-        panel_id = int(await self.send_result_command('RID'), 16)
+      panel_id = int(await self.send_result_command('RID'), 16)
       self._crypt.set_panel_id(panel_id)
       if not await self.send_ack_command('LCL'):
         raise CannotConnectError

--- a/pyrisco/local/risco_socket.py
+++ b/pyrisco/local/risco_socket.py
@@ -33,7 +33,10 @@ class RiscoSocket:
       self._queue = asyncio.Queue()
       self._listen_task = asyncio.create_task(self._listen())
       self._crypt = RiscoCrypt(self._encoding)
-      panel_id = int(await self.send_result_command('RID'))
+      try:
+        panel_id = int(await self.send_result_command('RID'))
+      except ValueError:
+        panel_id = int(await self.send_result_command('RID'), 16)
       self._crypt.set_panel_id(panel_id)
       if not await self.send_ack_command('LCL'):
         raise CannotConnectError


### PR DESCRIPTION
As discussed in #9, this PR adds support for the new Risco RW432MP panel (e.g. LightSys+).