### PR TITLE
Handle the out of Memory error by counting subsequent timeouts - keep alive - Implement ConnectionError

### DIFF
--- a/pyrisco/__init__.py
+++ b/pyrisco/__init__.py
@@ -1,3 +1,3 @@
 from pyrisco.local import RiscoLocal
 from pyrisco.cloud import RiscoCloud
-from .common import CannotConnectError, OperationError, UnauthorizedError
+from .common import CannotConnectError, ConnectionError, OperationError, UnauthorizedError

--- a/pyrisco/common.py
+++ b/pyrisco/common.py
@@ -140,6 +140,8 @@ class UnauthorizedError(Exception):
 class CannotConnectError(Exception):
   """Exception to indicate an error in authorization."""
 
+class ConnectionError(Exception):
+  """Exception to indicate an error with the connection."""
 
 class OperationError(Exception):
   """Exception to indicate an error in operation."""

--- a/pyrisco/local/risco_local.py
+++ b/pyrisco/local/risco_local.py
@@ -6,7 +6,7 @@ from .partition import Partition
 from .zone import Zone
 from .system import System
 from .risco_socket import RiscoSocket
-from pyrisco.common import OperationError, GROUP_ID_TO_NAME
+from pyrisco.common import OperationError, ConnectionError, GROUP_ID_TO_NAME
 
 
 class RiscoLocal:
@@ -204,7 +204,7 @@ class RiscoLocal:
         item = await queue.get()
         if isinstance(item, Exception):
           self._error(item)
-          if isinstance(item, ConnectionResetError):
+          if isinstance(item, ConnectionError):
             await self.disconnect()
             break
           continue

--- a/pyrisco/local/risco_socket.py
+++ b/pyrisco/local/risco_socket.py
@@ -12,7 +12,7 @@ class RiscoSocket:
     self._code = code
     self._encoding = kwargs.get('encoding', 'utf-8')
     self._max_concurrency = kwargs.get('concurrency', 4)
-    self._communication_delay = kwargs.get('communication_delay', 0)
+    self._communication_delay = kwargs.get('communication_delay', 1)
     self._reader = None
     self._writer = None
     self._crypt = None

--- a/pyrisco/local/risco_socket.py
+++ b/pyrisco/local/risco_socket.py
@@ -78,9 +78,6 @@ class RiscoSocket:
             future.set_result(command)
         else:
           await self._handle_incoming(cmd_id, command, crc)
-      except ConnectionResetError as error:
-        await self._queue.put(error)
-        break
       except Exception as error:
         await self._queue.put(error)
 

--- a/pyrisco/local/risco_socket.py
+++ b/pyrisco/local/risco_socket.py
@@ -1,6 +1,6 @@
 import asyncio
 from .risco_crypt import RiscoCrypt, ESCAPED_END, END
-from pyrisco.common import UnauthorizedError, CannotConnectError, OperationError
+from pyrisco.common import UnauthorizedError, CannotConnectError, ConnectionError, OperationError
 
 MIN_CMD_ID = 1
 MAX_CMD_ID = 49
@@ -13,6 +13,7 @@ class RiscoSocket:
     self._encoding = kwargs.get('encoding', 'utf-8')
     self._max_concurrency = kwargs.get('concurrency', 4)
     self._communication_delay = kwargs.get('communication_delay', 1)
+    self._max_timeout_keep_alive_subseq = kwargs.get('max_timeout_subseq', 3)
     self._reader = None
     self._writer = None
     self._crypt = None
@@ -89,8 +90,19 @@ class RiscoSocket:
       try:
         await self.send_result_command("CLOCK")
       except OperationError as error:
-        await self._queue.put(error)
-
+        timeout_keep_alive_subseq += 1
+        try:
+          if self._max_timeout_keep_alive_subseq > 0:
+            if timeout_keep_alive_subseq >= self._max_timeout_keep_alive_subseq:
+              raise ConnectionError
+        except Exception as error:
+          await self._queue.put(error)
+          break
+        else: 
+          await self._queue.put(error)
+      else:
+        timeout_keep_alive_subseq = 0
+        
       await asyncio.sleep(5)
 
   async def send_ack_command(self, command):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.66.6'
+VERSION = '0.6.5'
 
 REQUIRED = ['aiohttp']
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.66.5'
+VERSION = '0.66.6'
 
 REQUIRED = ['aiohttp']
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.6.4'
+VERSION = '0.66.5'
 
 REQUIRED = ['aiohttp']
 


### PR DESCRIPTION
Hello OnFreund,

i tested a few things regarding the "out of Memory error" https://github.com/home-assistant/core/issues/119138 over the last weeks, just right before you updated your repository -- in fact i came a bit late with this now  :)

I don´t know if my changes would fit your standard. But in fact it solves the problem with out of memory in my case compleatly.
(i´m using pyrisco with HomeAssistant in local) !

- Created parameter "max_timeout_keep_alive_subseq" in pyrisco
 --> If a "Timeout CLOCK" happens 3 times subseqently, i´m raising an error "ConnectionError"
In my test together with HomeAssistant Integration i checking for the error the same way you do for "ConnectionResetError" (__init___.py) and starting a reload of the Integration when "ConnectionError" is raised by pyrisco.

I would be happy if you can take parts of my changes for everyone´s needs.

Best regards

Jakob

