### PR TITLE
RiscoCloud: Include parameters from_control_panel, fallback_to_cloud and proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ Python 3.7 and above are supported.
 
 ### Cloud
 
+#### Cloud From control panel and fallback to Cloud
+
+When requesting RiscoCloud information two modes are available:
+- `from_control_panel=True` will request to RiscoCloud to connect to your alarm's control panel directly (via the cloud). This mode allows triggered zones to be updated in real-time.
+- `from_control_panel=False` will request to RiscoCloud the latest known information published by your alarm's control panel to RiscoCloud. This mode does not provide real-time triggered zones information but is more reliable in case of temporary network issues.
+
+In case of temporary outage (network or configuration issue) between your alarm's panel and RiscoCloud, if `from_control_panel=True`
+is set, an OperationError will be raised after 3 retries.
+
+To avoid raising an OperationError in case of temporary outage, you can set `from_control_panel=True` and use `fallback_to_cloud=True` to fall back to RiscoCloud in case of error.
+A property `is_from_control_panel` is set on Alarm object to indicate if the information is coming from the control panel or from the cloud.
+
+#### Cloud with Proxy
+
+Proxy use is supported by passing a `proxy` and `proxy_auth` (optional) parameter to the `RiscoCloud` constructor.
+See [aiohttp documentation](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support) for more information.
+
+### Examples
+
 See Cloud examples in [examples](examples) folder.
 
 ```python
@@ -24,7 +43,7 @@ from pyrisco import RiscoCloud
 async def test_cloud():
     # from_control_panel=True will request to riscocloud to connect to your alarm's control panel directly (via the cloud)
     # this could not be possible if your alarm has connectivity issues (alarm setup, firewall filtering, alarm's internet connectivity issue)
-    r = RiscoCloud("<username>", "<password>", "<pincode>", from_control_panel=True)
+    r = RiscoCloud("<username>", "<password>", "<pincode>", from_control_panel=True, fallback_to_cloud=True)
 
     # you can also pass your own session to login. It will not be closed    
     await r.login()
@@ -58,6 +77,7 @@ async def test_cloud():
 
 asyncio.run(test_cloud())
 ```
+
 
 ### Local
 ```python

--- a/README.md
+++ b/README.md
@@ -15,87 +15,100 @@ Python 3.7 and above are supported.
 
 ### Cloud
 ```python
+import asyncio
 from pyrisco import RiscoCloud
-r = RiscoCloud("<username>", "<password>", "<pincode>")
 
-# you can also pass your own session to login. It will not be closed
-await r.login()
-alarm = await r.get_state()
-# partitions and zones are zero-based in Cloud
-print(alarm.partitions[0].armed)
+async def test_cloud():
+    # from_control_panel=True will request to riscocloud to connect to your alarm's control panel directly (via the cloud)
+    # this could not be possible if your alarm has connectivity issues (alarm setup, firewall filtering, alarm's internet connectivity issue)
+    r = RiscoCloud("<username>", "<password>", "<pincode>", from_control_panel=True)
 
-events = await r.get_events("2020-06-17T00:00:00Z", 10)
-print(events[0].name)
+    # you can also pass your own session to login. It will not be closed    
+    await r.login()
+    alarm = await r.get_state()
+    # partitions and zones are zero-based in Cloud
+    print(alarm.partitions[0].armed)
+    
+    events = await r.get_events("2020-01-01T00:00:00Z", 10)
+    print(events[0].name)
+    
+    print(alarm.zones[0].name)
+    print(alarm.zones[0].triggered)
+    print(alarm.zones[0].bypassed)
+    
+    # arm partition 0
+    await r.partitions[0].arm()
+    
+    # and disarm it
+    await r.partitions[0].disarm()
+    
+    # Partial arming
+    await r.partitions[0].partial_arm()
+    
+    # Group arming
+    await r.partitions[0].group_arm("B")
+    # or a zero based index
+    await r.partitions[0].group_arm(1)
+    
+    # Don't forget to close when you're done
+    await r.close()
 
-print(alarm.zones[0].name)
-print(alarm.zones[0].triggered)
-print(alarm.zones[0].bypassed)
-
-# arm partition 0
-await r.partitions[0].arm()
-
-# and disarm it
-await r.partitions[0].disarm()
-
-# Partial arming
-await r.partitions[0].partial_arm()
-
-# Group arming
-await r.partitions[0].group_arm("B")
-# or a zero based index
-await r.partitions[0].group_arm(1)
-
-# Don't forget to close when you're done
-await r.close()
+asyncio.run(test_cloud())
 ```
 
 ### Local
 ```python
+import asyncio
 from pyrisco import RiscoLocal
-r = RiscoLocal("<host>", <port>, "<pincode>")
 
-await r.connect()
+async def test_local():
+    # r = RiscoLocal("<host>", <port>, "<pincode>")
+    r = RiscoLocal("<host>", 1000, "<pincode>")
 
-# Register handlers
-async def _error(error):
-  print(f'Error handler: {error}')
-remove_error = r.add_error_handler(_error)
-async def _event(event):
-  print(f'Event handler: {event}')
-remove_event = r.add_event_handler(_event)
-async def _default(command, result, *params):
-  print(f'Default handler: {command}, {result}, {params}')
-remove_default = r.add_default_handler(_default)
-async def _zone(zone_id, zone):
-  print(f'Zone handler: {zone_id}, {vars(zone)}')
-remove_zone = r.add_zone_handler(_zone)
-async def _partition(partition_id, partition):
-  print(f'Partition handler: {partition_id}, {vars(partition)}')
-remove_partition = r.add_partition_handler(_partition)
+    await r.connect()
+    
+    # Register handlers
+    async def _error(error):
+      print(f'Error handler: {error}')
+    remove_error = r.add_error_handler(_error)
+    async def _event(event):
+      print(f'Event handler: {event}')
+    remove_event = r.add_event_handler(_event)
+    async def _default(command, result, *params):
+      print(f'Default handler: {command}, {result}, {params}')
+    remove_default = r.add_default_handler(_default)
+    async def _zone(zone_id, zone):
+      print(f'Zone handler: {zone_id}, {vars(zone)}')
+    remove_zone = r.add_zone_handler(_zone)
+    async def _partition(partition_id, partition):
+      print(f'Partition handler: {partition_id}, {vars(partition)}')
+    remove_partition = r.add_partition_handler(_partition)
+    
+    await r.connect()
+    # partitions and zones are one-based in Cloud
+    print(r.partitions[1].armed)
+    
+    
+    print(r.zones[1].name)
+    print(r.zones[1].triggered)
+    print(r.zones[1].bypassed)
+    
+    # arm partition 1
+    await r.partitions[1].arm()
+    
+    # and disarm it
+    await r.partitions[1].disarm()
+    
+    # Partial arming
+    await r.partitions[1].partial_arm()
+    
+    # Group arming
+    await r.partitions[1].group_arm("B")
+    # or a zero based index
+    await r.partitions[1].group_arm(1)
+    
+    # Don't forget to close when you're done
+    await r.disconnect()
 
-await r.connect()
-# partitions and zones are one-based in Cloud
-print(r.partitions[1].armed)
-
-
-print(r.zones[1].name)
-print(r.zones[1].triggered)
-print(r.zones[1].bypassed)
-
-# arm partition 1
-await r.partitions[1].arm()
-
-# and disarm it
-await r.partitions[1].disarm()
-
-# Partial arming
-await r.partitions[1].partial_arm()
-
-# Group arming
-await r.partitions[1].group_arm("B")
-# or a zero based index
-await r.partitions[1].group_arm(1)
-
-# Don't forget to close when you're done
-await r.disconnect()
+asyncio.run(test_local())
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Python 3.7 and above are supported.
 ## How to use
 
 ### Cloud
+
+See Cloud examples in [examples](examples) folder.
+
 ```python
 import asyncio
 from pyrisco import RiscoCloud

--- a/examples/cloud/cloud_base_example.py
+++ b/examples/cloud/cloud_base_example.py
@@ -1,0 +1,29 @@
+from pyrisco import RiscoCloud
+from tabulate import tabulate
+
+
+class RiscoCloudBaseExample:
+  def __init__(self, username, password, pin,
+               from_control_panel=True, fallback_to_cloud=True,
+               proxy=None, proxy_auth=None):
+    self.risco_cloud = RiscoCloud(
+      username, password, pin,
+      proxy=proxy,
+      proxy_auth=proxy_auth,
+      from_control_panel=from_control_panel,
+      fallback_to_cloud=fallback_to_cloud)
+
+  def tabulate(self, dataset):
+    if len(dataset) == 0:
+      print("No data")
+      return
+    dataset = list(dataset)
+    headers = dataset[0]._raw.keys()
+    rows = [x._raw.values() for x in dataset]
+    print(tabulate(rows, headers=headers))
+
+  async def login(self):
+    return await self.risco_cloud.login()
+
+  async def close(self):
+    return await self.risco_cloud.close()

--- a/examples/cloud/cloud_check_sensors_loop.py
+++ b/examples/cloud/cloud_check_sensors_loop.py
@@ -5,45 +5,46 @@ from datetime import datetime, timedelta
 
 
 class RiscoCloudCheckZonesLoopExample:
-    def __init__(self, username, password, pin, interval=10, from_control_panel=True):
-        self.username = username
-        self.password = password
-        self.pin = pin
-        self.from_control_panel = from_control_panel
-        self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
-        self.sensor_check_interval = interval  # seconds
-        self.zones = []
+  def __init__(self, username, password, pin, interval=10, from_control_panel=True):
+    self.username = username
+    self.password = password
+    self.pin = pin
+    self.from_control_panel = from_control_panel
+    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
+    self.sensor_check_interval = interval  # seconds
+    self.zones = []
 
-    async def login(self):
-        return await self.risco_cloud.login()
+  async def login(self):
+    return await self.risco_cloud.login()
 
-    async def close(self):
-        return await self.risco_cloud.close()
+  async def close(self):
+    return await self.risco_cloud.close()
 
-    def tabulate(self, dataset):
-        if (len(dataset) == 0):
-            print("No data")
-            return
-        dataset = list(dataset)
-        headers = dataset[0]._raw.keys()
-        rows = [x._raw.values() for x in dataset]
-        print(tabulate(rows, headers=headers))
+  def tabulate(self, dataset):
+    if len(dataset) == 0:
+      print("No data")
+      return
+    dataset = list(dataset)
+    headers = dataset[0]._raw.keys()
+    rows = [x._raw.values() for x in dataset]
+    print(tabulate(rows, headers=headers))
 
-    async def check_zones(self):
-        await self.login()
-        try:
-            while True:
-                state = await self.risco_cloud.get_state()
-                triggered = [zone.zoneID for zone in state.zones.values() if zone.triggered]
-                if triggered:
-                    print('\n')
-                    self.tabulate([state.zones[zone] for zone in triggered])
-                else:
-                    print("\r", end="")
-                print('{}, number of zones: {}'.format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), len(state.zones.values())), end="")
-                await asyncio.sleep(self.sensor_check_interval)
-        finally:
-            await self.close()
+  async def check_zones(self):
+    await self.login()
+    try:
+      while True:
+        state = await self.risco_cloud.get_state()
+        triggered = [zone.zoneID for zone in state.zones.values() if zone.triggered]
+        if triggered:
+          print('\n')
+          self.tabulate([state.zones[zone] for zone in triggered])
+        else:
+          print("\r", end="")
+        print('{}, number of zones: {}'.format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), len(state.zones.values())),
+              end="")
+        await asyncio.sleep(self.sensor_check_interval)
+    finally:
+      await self.close()
 
 
 # username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )

--- a/examples/cloud/cloud_check_sensors_loop.py
+++ b/examples/cloud/cloud_check_sensors_loop.py
@@ -1,0 +1,51 @@
+import asyncio
+from pyrisco import RiscoCloud
+from tabulate import tabulate
+from datetime import datetime, timedelta
+
+
+class RiscoCloudCheckZonesLoopExample:
+    def __init__(self, username, password, pin, interval=10, from_control_panel=True):
+        self.username = username
+        self.password = password
+        self.pin = pin
+        self.from_control_panel = from_control_panel
+        self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
+        self.sensor_check_interval = interval  # seconds
+        self.zones = []
+
+    async def login(self):
+        return await self.risco_cloud.login()
+
+    async def close(self):
+        return await self.risco_cloud.close()
+
+    def tabulate(self, dataset):
+        if (len(dataset) == 0):
+            print("No data")
+            return
+        dataset = list(dataset)
+        headers = dataset[0]._raw.keys()
+        rows = [x._raw.values() for x in dataset]
+        print(tabulate(rows, headers=headers))
+
+    async def check_zones(self):
+        await self.login()
+        try:
+            while True:
+                state = await self.risco_cloud.get_state()
+                triggered = [zone.zoneID for zone in state.zones.values() if zone.triggered]
+                if triggered:
+                    print('\n')
+                    self.tabulate([state.zones[zone] for zone in triggered])
+                else:
+                    print("\r", end="")
+                print('{}, number of zones: {}'.format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"), len(state.zones.values())), end="")
+                await asyncio.sleep(self.sensor_check_interval)
+        finally:
+            await self.close()
+
+
+# username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
+r = RiscoCloudCheckZonesLoopExample("username", "password", "pin", from_control_panel=True)
+asyncio.run(r.check_zones())

--- a/examples/cloud/cloud_example.py
+++ b/examples/cloud/cloud_example.py
@@ -1,37 +1,17 @@
 import asyncio
-from pyrisco import RiscoCloud
-from tabulate import tabulate
+
+from cloud_base_example import RiscoCloudBaseExample
 from datetime import datetime, timedelta
 
 
-class RiscoCloudExample:
-  def __init__(self, username, password, pin, from_control_panel=True):
-    self.username = username
-    self.password = password
-    self.pin = pin
-    self.from_control_panel = from_control_panel
-    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
-
-  async def login(self):
-    return await self.risco_cloud.login()
-
-  async def close(self):
-    return await self.risco_cloud.close()
-
-  def tabulate(self, dataset):
-    if (len(dataset) == 0):
-      print("No data")
-      return
-    dataset = list(dataset)
-    headers = dataset[0]._raw.keys()
-    rows = [x._raw.values() for x in dataset]
-    print(tabulate(rows, headers=headers))
+class RiscoCloudExample(RiscoCloudBaseExample):
 
   async def display_state(self):
     await self.login()
     state = await self.risco_cloud.get_state()
     print('==================== Alarm status ====================')
-    ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
+    ALARM_PROPERTIES = ['is_from_control_panel',
+                        'cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
                         'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time',
                         'last_log_update', 'last_status_update', 'last_event_reported']
     for prop in ALARM_PROPERTIES:
@@ -88,6 +68,6 @@ class RiscoCloudExample:
 
 
 # username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
-r = RiscoCloudExample("username", "password", "pin", from_control_panel=True)
+r = RiscoCloudExample("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)
 asyncio.run(r.display_state())
 asyncio.run(r.display_events(datetime.now() - timedelta(days=1), 100))

--- a/examples/cloud/cloud_example.py
+++ b/examples/cloud/cloud_example.py
@@ -1,0 +1,91 @@
+import asyncio
+from pyrisco import RiscoCloud
+from tabulate import tabulate
+from datetime import datetime, timedelta
+
+
+class RiscoCloudExample:
+    def __init__(self, username, password, pin, from_control_panel=True):
+        self.username = username
+        self.password = password
+        self.pin = pin
+        self.from_control_panel = from_control_panel
+        self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
+
+    async def login(self):
+        return await self.risco_cloud.login()
+
+    async def close(self):
+        return await self.risco_cloud.close()
+
+    def tabulate(self, dataset):
+        if (len(dataset) == 0):
+            print("No data")
+            return
+        dataset = list(dataset)
+        headers = dataset[0]._raw.keys()
+        rows = [x._raw.values() for x in dataset]
+        print(tabulate(rows, headers=headers))
+
+    async def display_state(self):
+        await self.login()
+        state = await self.risco_cloud.get_state()
+        print('==================== Alarm status ====================')
+        ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on', 'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time', 'last_log_update', 'last_status_update', 'last_event_reported']
+        for prop in ALARM_PROPERTIES:
+            print(f'{prop}: {getattr(state, prop)}')
+        print('==================== Partitions ====================')
+        self.tabulate(state.partitions.values())
+        print('==================== Zones ====================')
+        self.tabulate(state.zones.values())
+        print('==================== Device collections ====================')
+        for device_type, collection in state.dev_collections.items():
+            print(f'Collection Type: {device_type}')
+            self.tabulate(collection.devices.values())
+        print('==================== Users ====================')
+        self.tabulate(state.users.values())
+        await self.close()
+
+    async def display_events(self, start_date, limit):
+        await self.login()
+        events = await self.risco_cloud.get_events(start_date.strftime('%Y-%m-%d'), limit)
+        print('==================== Events ====================')
+        self.tabulate(events)
+        await self.close()
+
+    async def test(self):
+        """Example from README.md"""
+        await self.login()
+        alarm = await r.get_state()
+        # partitions and zones are zero-based in Cloud
+        print(alarm.partitions[0].armed)
+
+        events = await r.get_events("2020-01-01T00:00:00Z", 10)
+        print(events[0].name)
+
+        print(alarm.zones[0].name)
+        print(alarm.zones[0].triggered)
+        print(alarm.zones[0].bypassed)
+
+        # arm partition 0
+        await r.partitions[0].arm()
+
+        # and disarm it
+        await r.partitions[0].disarm()
+
+        # Partial arming
+        await r.partitions[0].partial_arm()
+
+        # Group arming
+        await r.partitions[0].group_arm("B")
+        # or a zero based index
+        await r.partitions[0].group_arm(1)
+
+        # Don't forget to close when you're done
+        await self.close()
+
+
+# username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
+r = RiscoCloudExample("username", "password", "pin", from_control_panel=True)
+asyncio.run(r.display_state())
+asyncio.run(r.display_events(datetime.now() - timedelta(days=1), 100))

--- a/examples/cloud/cloud_example.py
+++ b/examples/cloud/cloud_example.py
@@ -5,84 +5,86 @@ from datetime import datetime, timedelta
 
 
 class RiscoCloudExample:
-    def __init__(self, username, password, pin, from_control_panel=True):
-        self.username = username
-        self.password = password
-        self.pin = pin
-        self.from_control_panel = from_control_panel
-        self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
+  def __init__(self, username, password, pin, from_control_panel=True):
+    self.username = username
+    self.password = password
+    self.pin = pin
+    self.from_control_panel = from_control_panel
+    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, from_control_panel=self.from_control_panel)
 
-    async def login(self):
-        return await self.risco_cloud.login()
+  async def login(self):
+    return await self.risco_cloud.login()
 
-    async def close(self):
-        return await self.risco_cloud.close()
+  async def close(self):
+    return await self.risco_cloud.close()
 
-    def tabulate(self, dataset):
-        if (len(dataset) == 0):
-            print("No data")
-            return
-        dataset = list(dataset)
-        headers = dataset[0]._raw.keys()
-        rows = [x._raw.values() for x in dataset]
-        print(tabulate(rows, headers=headers))
+  def tabulate(self, dataset):
+    if (len(dataset) == 0):
+      print("No data")
+      return
+    dataset = list(dataset)
+    headers = dataset[0]._raw.keys()
+    rows = [x._raw.values() for x in dataset]
+    print(tabulate(rows, headers=headers))
 
-    async def display_state(self):
-        await self.login()
-        state = await self.risco_cloud.get_state()
-        print('==================== Alarm status ====================')
-        ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on', 'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time', 'last_log_update', 'last_status_update', 'last_event_reported']
-        for prop in ALARM_PROPERTIES:
-            print(f'{prop}: {getattr(state, prop)}')
-        print('==================== Partitions ====================')
-        self.tabulate(state.partitions.values())
-        print('==================== Zones ====================')
-        self.tabulate(state.zones.values())
-        print('==================== Device collections ====================')
-        for device_type, collection in state.dev_collections.items():
-            print(f'Collection Type: {device_type}')
-            self.tabulate(collection.devices.values())
-        print('==================== Users ====================')
-        self.tabulate(state.users.values())
-        await self.close()
+  async def display_state(self):
+    await self.login()
+    state = await self.risco_cloud.get_state()
+    print('==================== Alarm status ====================')
+    ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
+                        'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time',
+                        'last_log_update', 'last_status_update', 'last_event_reported']
+    for prop in ALARM_PROPERTIES:
+      print(f'{prop}: {getattr(state, prop)}')
+    print('==================== Partitions ====================')
+    self.tabulate(state.partitions.values())
+    print('==================== Zones ====================')
+    self.tabulate(state.zones.values())
+    print('==================== Device collections ====================')
+    for device_type, collection in state.dev_collections.items():
+      print(f'Collection Type: {device_type}')
+      self.tabulate(collection.devices.values())
+    print('==================== Users ====================')
+    self.tabulate(state.users.values())
+    await self.close()
 
-    async def display_events(self, start_date, limit):
-        await self.login()
-        events = await self.risco_cloud.get_events(start_date.strftime('%Y-%m-%d'), limit)
-        print('==================== Events ====================')
-        self.tabulate(events)
-        await self.close()
+  async def display_events(self, start_date, limit):
+    await self.login()
+    events = await self.risco_cloud.get_events(start_date.strftime('%Y-%m-%d'), limit)
+    print('==================== Events ====================')
+    self.tabulate(events)
+    await self.close()
 
-    async def test(self):
-        """Example from README.md"""
-        await self.login()
-        alarm = await r.get_state()
-        # partitions and zones are zero-based in Cloud
-        print(alarm.partitions[0].armed)
+  async def test(self):
+    """Example from README.md"""
+    await self.login()
+    alarm = await r.get_state()
+    # partitions and zones are zero-based in Cloud
+    print(alarm.partitions[0].armed)
 
-        events = await r.get_events("2020-01-01T00:00:00Z", 10)
-        print(events[0].name)
+    events = await r.get_events("2020-01-01T00:00:00Z", 10)
+    print(events[0].name)
 
-        print(alarm.zones[0].name)
-        print(alarm.zones[0].triggered)
-        print(alarm.zones[0].bypassed)
+    print(alarm.zones[0].name)
+    print(alarm.zones[0].triggered)
+    print(alarm.zones[0].bypassed)
 
-        # arm partition 0
-        await r.partitions[0].arm()
+    # arm partition 0
+    await r.partitions[0].arm()
 
-        # and disarm it
-        await r.partitions[0].disarm()
+    # and disarm it
+    await r.partitions[0].disarm()
 
-        # Partial arming
-        await r.partitions[0].partial_arm()
+    # Partial arming
+    await r.partitions[0].partial_arm()
 
-        # Group arming
-        await r.partitions[0].group_arm("B")
-        # or a zero based index
-        await r.partitions[0].group_arm(1)
+    # Group arming
+    await r.partitions[0].group_arm("B")
+    # or a zero based index
+    await r.partitions[0].group_arm(1)
 
-        # Don't forget to close when you're done
-        await self.close()
+    # Don't forget to close when you're done
+    await self.close()
 
 
 # username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )

--- a/examples/cloud/cloud_example_proxy.py
+++ b/examples/cloud/cloud_example_proxy.py
@@ -1,0 +1,93 @@
+import asyncio
+from pyrisco import RiscoCloud
+from tabulate import tabulate
+from datetime import datetime, timedelta
+
+
+class RiscoCloudProxyExample:
+    def __init__(self, username, password, pin, from_control_panel=True, proxy=None, proxy_auth=None):
+        self.username = username
+        self.password = password
+        self.pin = pin
+        self.from_control_panel = from_control_panel
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
+        self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, proxy=self.proxy, proxy_auth=self.proxy_auth, from_control_panel=self.from_control_panel)
+
+    async def login(self):
+        return await self.risco_cloud.login()
+
+    async def close(self):
+        return await self.risco_cloud.close()
+
+    def tabulate(self, dataset):
+        if (len(dataset) == 0):
+            print("No data")
+            return
+        dataset = list(dataset)
+        headers = dataset[0]._raw.keys()
+        rows = [x._raw.values() for x in dataset]
+        print(tabulate(rows, headers=headers))
+
+    async def display_state(self):
+        await self.login()
+        state = await self.risco_cloud.get_state()
+        print('==================== Alarm status ====================')
+        ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on', 'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time', 'last_log_update', 'last_status_update', 'last_event_reported']
+        for prop in ALARM_PROPERTIES:
+            print(f'{prop}: {getattr(state, prop)}')
+        print('==================== Partitions ====================')
+        self.tabulate(state.partitions.values())
+        print('==================== Zones ====================')
+        self.tabulate(state.zones.values())
+        print('==================== Device collections ====================')
+        for device_type, collection in state.dev_collections.items():
+            print(f'Collection Type: {device_type}')
+            self.tabulate(collection.devices.values())
+        print('==================== Users ====================')
+        self.tabulate(state.users.values())
+        await self.close()
+
+    async def display_events(self, start_date, limit):
+        await self.login()
+        events = await self.risco_cloud.get_events(start_date.strftime('%Y-%m-%d'), limit)
+        print('==================== Events ====================')
+        self.tabulate(events)
+        await self.close()
+
+    async def test(self):
+        """Example from README.md"""
+        await self.login()
+        alarm = await r.get_state()
+        # partitions and zones are zero-based in Cloud
+        print(alarm.partitions[0].armed)
+
+        events = await r.get_events("2020-01-01T00:00:00Z", 10)
+        print(events[0].name)
+
+        print(alarm.zones[0].name)
+        print(alarm.zones[0].triggered)
+        print(alarm.zones[0].bypassed)
+
+        # arm partition 0
+        await r.partitions[0].arm()
+
+        # and disarm it
+        await r.partitions[0].disarm()
+
+        # Partial arming
+        await r.partitions[0].partial_arm()
+
+        # Group arming
+        await r.partitions[0].group_arm("B")
+        # or a zero based index
+        await r.partitions[0].group_arm(1)
+
+        # Don't forget to close when you're done
+        await self.close()
+
+
+# username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
+r = RiscoCloudProxyExample("username", "password", "pin", from_control_panel=True, proxy="http://192.168.1.2:8080")
+asyncio.run(r.display_state())
+asyncio.run(r.display_events(datetime.now() - timedelta(days=1), 100))

--- a/examples/cloud/cloud_example_proxy.py
+++ b/examples/cloud/cloud_example_proxy.py
@@ -1,40 +1,17 @@
 import asyncio
-from pyrisco import RiscoCloud
-from tabulate import tabulate
 from datetime import datetime, timedelta
 
+from cloud_base_example import RiscoCloudBaseExample
 
-class RiscoCloudProxyExample:
-  def __init__(self, username, password, pin, from_control_panel=True, proxy=None, proxy_auth=None):
-    self.username = username
-    self.password = password
-    self.pin = pin
-    self.from_control_panel = from_control_panel
-    self.proxy = proxy
-    self.proxy_auth = proxy_auth
-    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, proxy=self.proxy, proxy_auth=self.proxy_auth,
-                                  from_control_panel=self.from_control_panel)
 
-  async def login(self):
-    return await self.risco_cloud.login()
-
-  async def close(self):
-    return await self.risco_cloud.close()
-
-  def tabulate(self, dataset):
-    if (len(dataset) == 0):
-      print("No data")
-      return
-    dataset = list(dataset)
-    headers = dataset[0]._raw.keys()
-    rows = [x._raw.values() for x in dataset]
-    print(tabulate(rows, headers=headers))
+class RiscoCloudProxyExample(RiscoCloudBaseExample):
 
   async def display_state(self):
     await self.login()
     state = await self.risco_cloud.get_state()
     print('==================== Alarm status ====================')
-    ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
+    ALARM_PROPERTIES = ['is_from_control_panel',
+                        'cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
                         'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time',
                         'last_log_update', 'last_status_update', 'last_event_reported']
     for prop in ALARM_PROPERTIES:

--- a/examples/cloud/cloud_fallback_example.py
+++ b/examples/cloud/cloud_fallback_example.py
@@ -4,16 +4,16 @@ from tabulate import tabulate
 from datetime import datetime, timedelta
 
 
-class RiscoCloudProxyExample:
-  def __init__(self, username, password, pin, from_control_panel=True, proxy=None, proxy_auth=None):
+class RiscoCloudExample:
+  def __init__(self, username, password, pin, from_control_panel=True, fallback_to_cloud=False):
     self.username = username
     self.password = password
     self.pin = pin
     self.from_control_panel = from_control_panel
-    self.proxy = proxy
-    self.proxy_auth = proxy_auth
-    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin, proxy=self.proxy, proxy_auth=self.proxy_auth,
-                                  from_control_panel=self.from_control_panel)
+    self.fallback_to_cloud = fallback_to_cloud
+    self.risco_cloud = RiscoCloud(self.username, self.password, self.pin,
+                                  from_control_panel=self.from_control_panel,
+                                  fallback_to_cloud=self.fallback_to_cloud)
 
   async def login(self):
     return await self.risco_cloud.login()
@@ -22,7 +22,7 @@ class RiscoCloudProxyExample:
     return await self.risco_cloud.close()
 
   def tabulate(self, dataset):
-    if (len(dataset) == 0):
+    if len(dataset) == 0:
       print("No data")
       return
     dataset = list(dataset)
@@ -58,39 +58,7 @@ class RiscoCloudProxyExample:
     self.tabulate(events)
     await self.close()
 
-  async def test(self):
-    """Example from README.md"""
-    await self.login()
-    alarm = await r.get_state()
-    # partitions and zones are zero-based in Cloud
-    print(alarm.partitions[0].armed)
-
-    events = await r.get_events("2020-01-01T00:00:00Z", 10)
-    print(events[0].name)
-
-    print(alarm.zones[0].name)
-    print(alarm.zones[0].triggered)
-    print(alarm.zones[0].bypassed)
-
-    # arm partition 0
-    await r.partitions[0].arm()
-
-    # and disarm it
-    await r.partitions[0].disarm()
-
-    # Partial arming
-    await r.partitions[0].partial_arm()
-
-    # Group arming
-    await r.partitions[0].group_arm("B")
-    # or a zero based index
-    await r.partitions[0].group_arm(1)
-
-    # Don't forget to close when you're done
-    await self.close()
-
-
 # username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
-r = RiscoCloudProxyExample("username", "password", "pin", from_control_panel=True, proxy="http://192.168.1.2:8080")
+r = RiscoCloudExample("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)
 asyncio.run(r.display_state())
 asyncio.run(r.display_events(datetime.now() - timedelta(days=1), 100))

--- a/examples/cloud/cloud_fallback_example.py
+++ b/examples/cloud/cloud_fallback_example.py
@@ -34,7 +34,8 @@ class RiscoCloudExample:
     await self.login()
     state = await self.risco_cloud.get_state()
     print('==================== Alarm status ====================')
-    ALARM_PROPERTIES = ['cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
+    ALARM_PROPERTIES = ['is_from_control_panel',
+                        'cp_time', 'system_status', 'system_ready', 'trouble', 'bell_status', 'bell_on',
                         'alarm_pending', 'battery_low', 'ac_lost', 'is_online', 'last_connected_time',
                         'last_log_update', 'last_status_update', 'last_event_reported']
     for prop in ALARM_PROPERTIES:
@@ -57,6 +58,7 @@ class RiscoCloudExample:
     print('==================== Events ====================')
     self.tabulate(events)
     await self.close()
+
 
 # username, password, pin from Risco Cloud ( https://www.riscocloud.com/ )
 r = RiscoCloudExample("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)

--- a/pyrisco/cloud/alarm.py
+++ b/pyrisco/cloud/alarm.py
@@ -1,5 +1,8 @@
 from .partition import Partition
 from .zone import Zone
+from .user import User
+from .dev_collection import DevCollection
+
 
 class Alarm:
   """A representation of a Risco alarm system."""
@@ -8,19 +11,107 @@ class Alarm:
     """Read alarm from response."""
     self._api = api
     self._raw = raw
+    self._raw_status = raw["status"]
     self._partitions = None
     self._zones = None
+    self._users = None
+    self._dev_collections = None
+
+  @property
+  def is_online(self):
+    """Is the alarm online."""
+    return self._raw["isOnline"]
+
+  @property
+  def last_connected_time(self):
+    """Last connected time."""
+    return self._raw["lastConnectedTime"]
+
+  @property
+  def last_log_update(self):
+    """Last log update."""
+    return self._raw["lastLogUpdate"]
+
+  @property
+  def last_status_update(self):
+    """Last status update."""
+    return self._raw["lastStatusUpdate"]
+
+  @property
+  def last_event_reported(self):
+    """Last event reported."""
+    return self._raw["lastEvReported"]
+
+  @property
+  def cp_time(self):
+    """CP time."""
+    return self._raw_status["cpTime"]
+
+  @property
+  def system_status(self):
+    """System status."""
+    return self._raw_status["systemStatus"]
+
+  @property
+  def system_ready(self):
+    """System ready."""
+    return self._raw_status["systemReady"]
+
+  @property
+  def trouble(self):
+    """Trouble."""
+    return self._raw_status["trouble"]
+
+  @property
+  def bell_status(self):
+    """Bell status."""
+    return self._raw_status["bellStatus"]
+
+  @property
+  def bell_on(self):
+    """Bell on."""
+    return self._raw_status["bellOn"]
+
+  @property
+  def alarm_pending(self):
+    """Alarm pending."""
+    return self._raw_status["alarmPending"]
+
+  @property
+  def battery_low(self):
+    """Battery low."""
+    return self._raw_status["batteryLow"]
+
+  @property
+  def ac_lost(self):
+    """AC lost."""
+    return self._raw_status["acLost"]
 
   @property
   def partitions(self):
     """Alarm partitions."""
     if self._partitions is None:
-      self._partitions = {p["id"]: Partition(self._api, p) for p in self._raw["partitions"]}
+      self._partitions = {p["id"]: Partition(self._api, p) for p in self._raw_status.get("partitions", [])}
     return self._partitions
+
+  @property
+  def dev_collections(self):
+    """Alarm dev collections."""
+    if self._dev_collections is None:
+      self._dev_collections = {dc["devType"]: DevCollection(dc) for dc in self._raw_status.get("devCollection", [])}
+    return self._dev_collections
 
   @property
   def zones(self):
     """Alarm zones."""
     if self._zones is None:
-      self._zones = {z["zoneID"]: Zone(self._api, z) for z in self._raw["zones"]}
+      self._zones = {z["zoneID"]: Zone(self._api, z) for z in self._raw_status.get("zones", [])}
     return self._zones
+
+  @property
+  def users(self):
+    """Alarm users."""
+    if self._users is None:
+      enabled_users = [u for u in self._raw_status["users"] if u["userType"] != 9]
+      self._users = {z["userID"]: User(z) for z in enabled_users}
+    return self._users

--- a/pyrisco/cloud/alarm.py
+++ b/pyrisco/cloud/alarm.py
@@ -7,7 +7,7 @@ from .dev_collection import DevCollection
 class Alarm:
   """A representation of a Risco alarm system."""
 
-  def __init__(self, api, raw):
+  def __init__(self, api, raw, from_control_panel):
     """Read alarm from response."""
     self._api = api
     self._raw = raw
@@ -16,6 +16,12 @@ class Alarm:
     self._zones = None
     self._users = None
     self._dev_collections = None
+    self._from_control_panel = from_control_panel
+
+  @property
+  def is_from_control_panel(self):
+    """Is information comes from control Panel via RiscoCloud."""
+    return self._from_control_panel
 
   @property
   def is_online(self):

--- a/pyrisco/cloud/dev_collection.py
+++ b/pyrisco/cloud/dev_collection.py
@@ -1,0 +1,46 @@
+class Device:
+  """A representation of a Risco Device."""
+
+  def __init__(self, raw):
+    """Read event from response."""
+    self._raw = raw
+
+  @property
+  def raw(self):
+    return self._raw
+
+  @property
+  def num(self):
+    return self.raw["num"]
+
+  @property
+  def description(self):
+    return self.raw["description"]
+
+  @property
+  def extra(self):
+    return self.raw["extra"]
+
+
+class DevCollection:
+  """A representation of a Risco Device Collection."""
+
+  def __init__(self, raw):
+    """Read event from response."""
+    self._raw = raw
+    self._devices = None
+
+  @property
+  def raw(self):
+    return self._raw
+
+  @property
+  def device_type(self):
+    return self.raw["devType"]
+
+  @property
+  def devices(self):
+    """Alarm dev collections."""
+    if self._devices is None:
+      self._devices = {d["num"]: Device(d) for d in self._raw.get("devList", [])}
+    return self._devices

--- a/pyrisco/cloud/event.py
+++ b/pyrisco/cloud/event.py
@@ -17,6 +17,7 @@ EVENT_IDS_TO_TYPES = {
   121: "group arm",
 }
 
+
 class Event:
   """A representation of a Risco event."""
 
@@ -60,14 +61,24 @@ class Event:
     return self.raw["eventName"]
 
   @property
+  def description_hint(self):
+    """Event Description Hint."""
+    return self.raw["eventDescriptorHint"]
+
+  @property
   def category_id(self):
     """Event group number."""
     return self.raw["group"]
 
   @property
   def category_name(self):
-    """Event group number."""
+    """Event group name."""
     return self.raw["groupName"]
+
+  @property
+  def source_name(self):
+    """Event Source Name."""
+    return self.raw["sourceName"]
 
   @property
   def zone_id(self):
@@ -94,3 +105,8 @@ class Event:
   @property
   def source_id(self):
     return self._source_id
+
+  @property
+  def report_status(self):
+    """Event Report Status."""
+    return self.raw["reportStatus"]

--- a/pyrisco/cloud/partition.py
+++ b/pyrisco/cloud/partition.py
@@ -1,5 +1,6 @@
 from pyrisco.common import GROUP_ID_TO_NAME, Partition as BasePartition
 
+
 class Partition(BasePartition):
   """A representation of a Risco partition."""
 

--- a/pyrisco/cloud/user.py
+++ b/pyrisco/cloud/user.py
@@ -1,0 +1,38 @@
+USER_TYPES = {
+  9: "disabled",
+  12: "master",
+  13: "user",
+}
+
+
+class User:
+  """A representation of a Risco user."""
+
+  def __init__(self, raw):
+    """Read user from response."""
+    self._raw = raw
+
+  @property
+  def raw(self):
+    return self._raw
+
+  @property
+  def user_id(self):
+    return self.raw["userID"]
+
+  @property
+  def name(self):
+    return self.raw["userName"]
+
+  @property
+  def type_id(self):
+    return self.raw["userType"]
+
+  @property
+  def type_name(self):
+    return USER_TYPES.get(self.type_id, "unknown"),
+
+  @property
+  def part(self):
+    """User part."""
+    return self.raw["part"]

--- a/pyrisco/cloud/zone.py
+++ b/pyrisco/cloud/zone.py
@@ -1,5 +1,6 @@
 from pyrisco.common import GROUP_ID_TO_NAME, Zone as BaseZone
 
+
 class Zone(BaseZone):
   """A representation of a Risco zone."""
 

--- a/pyrisco/common.py
+++ b/pyrisco/common.py
@@ -138,11 +138,12 @@ class UnauthorizedError(Exception):
 
 
 class CannotConnectError(Exception):
-  """Exception to indicate an error in authorization."""
+  """Exception to indicate an error in connecting to Risco panel or Cloud."""
 
 
 class OperationError(Exception):
   """Exception to indicate an error in operation."""
+
 
 class RetryableOperationError(OperationError):
   """Exception to indicate an error in operation that can be retried and might succeed."""

--- a/pyrisco/common.py
+++ b/pyrisco/common.py
@@ -143,3 +143,6 @@ class CannotConnectError(Exception):
 
 class OperationError(Exception):
   """Exception to indicate an error in operation."""
+
+class RetryableOperationError(OperationError):
+  """Exception to indicate an error in operation that can be retried and might succeed."""

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.6.5'
+VERSION = '0.6.6'
 
 REQUIRED = ['aiohttp']
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,13 @@ REQUIRES_PYTHON = '>=3.7.0'
 VERSION = '0.6.6'
 
 REQUIRED = ['aiohttp']
+TEST_REQUIRE = ['pytest']
 
-EXTRAS = {}
-
+EXTRAS = {
+    'dev': [
+        'tabulate'
+    ]
+}
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -101,6 +105,7 @@ setup(
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
+    tests_require=TEST_REQUIRE,
     extras_require=EXTRAS,
     include_package_data=True,
     license='MIT',

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -1,0 +1,182 @@
+import unittest
+from unittest.mock import patch, AsyncMock
+from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError
+
+LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
+
+
+class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
+
+    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+    @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+    async def test_login(self, MockClientSession, mock_authenticated_post):
+        # Mock the aiohttp session and its methods
+        mock_session = MockClientSession.return_value
+        mock_post = AsyncMock()
+        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
+        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
+        mock_post.json = AsyncMock(return_value={
+            "status": 0,
+            "response": {
+                'accessToken': 'mock_access_token',
+                'classVersion': 0,
+                'expiresAt': '2025-02-01T20:40:03.6092768Z',
+                'refreshToken': 'mock_access_refresh_token',
+                'tokenType': 'Bearer'
+            }
+        })
+
+        # Mock the _authenticated_post method
+        mock_authenticated_post.side_effect = [
+            [{
+                "id": "mock_site_id",
+                "name": "mock_site_name",
+                "siteUUID": "mock_site_uuid"
+            }],
+            {
+                "sessionId": "mock_session_id"
+            }
+        ]
+
+        # Create an instance of RiscoCloud
+        risco_cloud = RiscoCloud("username", "password", "pin")
+
+        # Run the login method
+        await risco_cloud.login()
+
+        # Check if the access token is set correctly
+        self.assertEqual(risco_cloud._access_token, "mock_access_token")
+
+        # Check if the post method was called with the correct URL and headers
+        mock_session.post.assert_called_with(
+            LOGIN_URL,
+            headers={"Content-Type": "application/json"},
+            json={"userName": "username", "password": "password"}
+        )
+
+        # Check if the _authenticated_post method was called
+        mock_authenticated_post.assert_called()
+
+    @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+    async def test_login_unauthorized(self, MockClientSession):
+        # Mock the aiohttp session and its methods
+        mock_session = MockClientSession.return_value
+        mock_post = AsyncMock()
+        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
+        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
+        mock_post.json = AsyncMock(return_value={
+            "status": 0,
+            "response": {
+                'currentLoginAttempt': 2,
+                'errorText': 'invalid custom credential',
+                'errorTextCodeID': '0',
+                'maxLoginAttempts': 5,
+                'response': None,
+                'status': 401,
+                'validationErrors': None
+            }
+        })
+
+        # Create an instance of RiscoCloud
+        risco_cloud = RiscoCloud("username", "password", "pin")
+
+        with self.assertRaises(UnauthorizedError):
+            # Run the login method
+            await risco_cloud.login()
+
+        # Check if the post method was called with the correct URL and headers
+        mock_session.post.assert_called_with(
+            LOGIN_URL,
+            headers={"Content-Type": "application/json"},
+            json={"userName": "username", "password": "password"}
+        )
+
+    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+    async def test_get_state_with_retries(self, mock_authenticated_post):
+        # Mock the _site_post method to raise RetryableOperationError for the first two calls
+        mock_authenticated_post.side_effect = [
+            RetryableOperationError("Retryable error"),
+            RetryableOperationError("Retryable error"),
+            # Successful response on the third call
+            {
+                "state": {"partitions": [], "zones": [], "status": {}}
+            }
+        ]
+
+        # Create an instance of RiscoCloud
+        risco_cloud = RiscoCloud("username", "password", "pin")
+
+        # Set the access token to avoid login
+        risco_cloud._access_token = "mock_access_token"
+        risco_cloud._site_id = "mock_site_id"
+        risco_cloud._session_id = "mock_session_id"
+
+        # Run the get_state method
+        state = await risco_cloud.get_state()
+
+        # Check if the state is returned correctly
+        self.assertEqual(state.partitions, {})
+        self.assertEqual(state.zones, {})
+
+        # Check if the _site_post method was called three times
+        self.assertEqual(mock_authenticated_post.call_count, 3)
+
+    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+    async def test_get_state_with_fails(self, mock_authenticated_post):
+        mock_authenticated_post.side_effect = [
+            RetryableOperationError("Retryable error"),
+            RetryableOperationError("Retryable error"),
+            OperationError("Operation error")
+        ]
+
+        # Create an instance of RiscoCloud
+        risco_cloud = RiscoCloud("username", "password", "pin")
+
+        # Set the access token to avoid login
+        risco_cloud._access_token = "mock_access_token"
+        risco_cloud._site_id = "mock_site_id"
+        risco_cloud._session_id = "mock_session_id"
+
+        with self.assertRaises(OperationError):
+            # Run the get_state method
+            await risco_cloud.get_state()
+
+        # Check if the _site_post method was called three times
+        self.assertEqual(mock_authenticated_post.call_count, 3)
+
+    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+    async def test_get_state_with_fallback_to_cloud(self, mock_authenticated_post):
+        # Mock the _site_post method to raise RetryableOperationError for the first call
+        mock_authenticated_post.side_effect = [
+            RetryableOperationError("Retryable error"),
+            # Successful response on the second call with fallback to cloud
+            {
+                "state": {"partitions": [], "zones": [], "status": {}}
+            }
+        ]
+
+        # Create an instance of RiscoCloud
+        risco_cloud = RiscoCloud("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)
+
+        # Set the access token to avoid login
+        risco_cloud._access_token = "mock_access_token"
+        risco_cloud._site_id = "mock_site_id"
+        risco_cloud._session_id = "mock_session_id"
+
+        # Run the get_state method
+        state = await risco_cloud.get_state()
+
+        # Check if the state is returned correctly
+        self.assertEqual(state.partitions, {})
+        self.assertEqual(state.zones, {})
+
+        # Check if the _site_post method was called twice
+        self.assertEqual(mock_authenticated_post.call_count, 2)
+
+        # Check if the _site_post calls contain the correct from_control_panel value
+        self.assertTrue(mock_authenticated_post.call_args_list[0][0][1]['fromControlPanel'])
+        self.assertFalse(mock_authenticated_post.call_args_list[1][0][1]['fromControlPanel'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -7,176 +7,202 @@ LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
 
 class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
-    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
-    @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-    async def test_login(self, MockClientSession, mock_authenticated_post):
-        # Mock the aiohttp session and its methods
-        mock_session = MockClientSession.return_value
-        mock_post = AsyncMock()
-        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
-        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
-        mock_post.json = AsyncMock(return_value={
-            "status": 0,
-            "response": {
-                'accessToken': 'mock_access_token',
-                'classVersion': 0,
-                'expiresAt': '2025-02-01T20:40:03.6092768Z',
-                'refreshToken': 'mock_access_refresh_token',
-                'tokenType': 'Bearer'
-            }
-        })
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_login(self, MockClientSession, mock_authenticated_post):
+    # Mock the aiohttp session and its methods
+    mock_session = MockClientSession.return_value
+    mock_post = AsyncMock()
+    mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
+    mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
+    mock_post.json = AsyncMock(return_value={
+      "status": 0,
+      "response": {
+        'accessToken': 'mock_access_token',
+        'classVersion': 0,
+        'expiresAt': '2025-02-01T20:40:03.6092768Z',
+        'refreshToken': 'mock_access_refresh_token',
+        'tokenType': 'Bearer'
+      }
+    })
 
-        # Mock the _authenticated_post method
-        mock_authenticated_post.side_effect = [
-            [{
-                "id": "mock_site_id",
-                "name": "mock_site_name",
-                "siteUUID": "mock_site_uuid"
-            }],
-            {
-                "sessionId": "mock_session_id"
-            }
-        ]
+    # Mock the _authenticated_post method
+    mock_authenticated_post.side_effect = [
+      [{
+        "id": "mock_site_id",
+        "name": "mock_site_name",
+        "siteUUID": "mock_site_uuid"
+      }],
+      {
+        "sessionId": "mock_session_id"
+      }
+    ]
 
-        # Create an instance of RiscoCloud
-        risco_cloud = RiscoCloud("username", "password", "pin")
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin")
 
-        # Run the login method
-        await risco_cloud.login()
+    # Run the login method
+    await risco_cloud.login()
 
-        # Check if the access token is set correctly
-        self.assertEqual(risco_cloud._access_token, "mock_access_token")
+    # Check if the access token is set correctly
+    self.assertEqual(risco_cloud._access_token, "mock_access_token")
 
-        # Check if the post method was called with the correct URL and headers
-        mock_session.post.assert_called_with(
-            LOGIN_URL,
-            headers={"Content-Type": "application/json"},
-            json={"userName": "username", "password": "password"}
-        )
+    # Check if the post method was called with the correct URL and headers
+    mock_session.post.assert_called_with(
+      LOGIN_URL,
+      headers={"Content-Type": "application/json"},
+      json={"userName": "username", "password": "password"}
+    )
 
-        # Check if the _authenticated_post method was called
-        mock_authenticated_post.assert_called()
+    # Check if the _authenticated_post method was called
+    mock_authenticated_post.assert_called()
 
-    @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-    async def test_login_unauthorized(self, MockClientSession):
-        # Mock the aiohttp session and its methods
-        mock_session = MockClientSession.return_value
-        mock_post = AsyncMock()
-        mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
-        mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
-        mock_post.json = AsyncMock(return_value={
-            "status": 0,
-            "response": {
-                'currentLoginAttempt': 2,
-                'errorText': 'invalid custom credential',
-                'errorTextCodeID': '0',
-                'maxLoginAttempts': 5,
-                'response': None,
-                'status': 401,
-                'validationErrors': None
-            }
-        })
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_login_unauthorized(self, MockClientSession):
+    # Mock the aiohttp session and its methods
+    mock_session = MockClientSession.return_value
+    mock_post = AsyncMock()
+    mock_session.post.return_value.__aenter__ = AsyncMock(return_value=mock_post)
+    mock_session.post.return_value.__aexit__ = AsyncMock(return_value=None)
+    mock_post.json = AsyncMock(return_value={
+      "status": 0,
+      "response": {
+        'currentLoginAttempt': 2,
+        'errorText': 'invalid custom credential',
+        'errorTextCodeID': '0',
+        'maxLoginAttempts': 5,
+        'response': None,
+        'status': 401,
+        'validationErrors': None
+      }
+    })
 
-        # Create an instance of RiscoCloud
-        risco_cloud = RiscoCloud("username", "password", "pin")
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin")
 
-        with self.assertRaises(UnauthorizedError):
-            # Run the login method
-            await risco_cloud.login()
+    with self.assertRaises(UnauthorizedError):
+      # Run the login method
+      await risco_cloud.login()
 
-        # Check if the post method was called with the correct URL and headers
-        mock_session.post.assert_called_with(
-            LOGIN_URL,
-            headers={"Content-Type": "application/json"},
-            json={"userName": "username", "password": "password"}
-        )
+    # Check if the post method was called with the correct URL and headers
+    mock_session.post.assert_called_with(
+      LOGIN_URL,
+      headers={"Content-Type": "application/json"},
+      json={"userName": "username", "password": "password"}
+    )
 
-    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
-    async def test_get_state_with_retries(self, mock_authenticated_post):
-        # Mock the _site_post method to raise RetryableOperationError for the first two calls
-        mock_authenticated_post.side_effect = [
-            RetryableOperationError("Retryable error"),
-            RetryableOperationError("Retryable error"),
-            # Successful response on the third call
-            {
-                "state": {"partitions": [], "zones": [], "status": {}}
-            }
-        ]
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+  async def test_get_state_with_retries(self, mock_authenticated_post):
+    # Mock the _site_post method to raise RetryableOperationError for the first two calls
+    mock_authenticated_post.side_effect = [
+      RetryableOperationError("Retryable error"),
+      RetryableOperationError("Retryable error"),
+      # Successful response on the third call
+      {
+        "state": {"partitions": [], "zones": [], "status": {}}
+      }
+    ]
 
-        # Create an instance of RiscoCloud
-        risco_cloud = RiscoCloud("username", "password", "pin")
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin", from_control_panel=True)
 
-        # Set the access token to avoid login
-        risco_cloud._access_token = "mock_access_token"
-        risco_cloud._site_id = "mock_site_id"
-        risco_cloud._session_id = "mock_session_id"
+    # Set the access token to avoid login
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
 
-        # Run the get_state method
-        state = await risco_cloud.get_state()
+    # Run the get_state method
+    state = await risco_cloud.get_state()
 
-        # Check if the state is returned correctly
-        self.assertEqual(state.partitions, {})
-        self.assertEqual(state.zones, {})
+    # Check if the state is returned correctly
+    self.assertEqual(state.partitions, {})
+    self.assertEqual(state.zones, {})
+    self.assertTrue(state.is_from_control_panel)
 
-        # Check if the _site_post method was called three times
-        self.assertEqual(mock_authenticated_post.call_count, 3)
+    # Check if the _site_post method was called three times
+    self.assertEqual(mock_authenticated_post.call_count, 3)
 
-    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
-    async def test_get_state_with_fails(self, mock_authenticated_post):
-        mock_authenticated_post.side_effect = [
-            RetryableOperationError("Retryable error"),
-            RetryableOperationError("Retryable error"),
-            OperationError("Operation error")
-        ]
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+  async def test_get_state_with_retries_fails(self, mock_authenticated_post):
+    # Mock the _site_post method to raise RetryableOperationError for the first two calls
+    mock_authenticated_post.side_effect = [
+      RetryableOperationError("Retryable error"),
+      RetryableOperationError("Retryable error"),
+      RetryableOperationError("Retryable error"),
+    ]
 
-        # Create an instance of RiscoCloud
-        risco_cloud = RiscoCloud("username", "password", "pin")
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin", from_control_panel=True)
 
-        # Set the access token to avoid login
-        risco_cloud._access_token = "mock_access_token"
-        risco_cloud._site_id = "mock_site_id"
-        risco_cloud._session_id = "mock_session_id"
+    # Set the access token to avoid login
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
 
-        with self.assertRaises(OperationError):
-            # Run the get_state method
-            await risco_cloud.get_state()
+    # Run the get_state method
+    with self.assertRaises(OperationError):
+      await risco_cloud.get_state()
 
-        # Check if the _site_post method was called three times
-        self.assertEqual(mock_authenticated_post.call_count, 3)
+    # Check if the _site_post method was called three times
+    self.assertEqual(mock_authenticated_post.call_count, 3)
 
-    @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
-    async def test_get_state_with_fallback_to_cloud(self, mock_authenticated_post):
-        # Mock the _site_post method to raise RetryableOperationError for the first call
-        mock_authenticated_post.side_effect = [
-            RetryableOperationError("Retryable error"),
-            # Successful response on the second call with fallback to cloud
-            {
-                "state": {"partitions": [], "zones": [], "status": {}}
-            }
-        ]
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+  async def test_get_state_with_fails(self, mock_authenticated_post):
+    mock_authenticated_post.side_effect = [
+      RetryableOperationError("Retryable error"),
+      RetryableOperationError("Retryable error"),
+      OperationError("Operation error")
+    ]
 
-        # Create an instance of RiscoCloud
-        risco_cloud = RiscoCloud("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin")
 
-        # Set the access token to avoid login
-        risco_cloud._access_token = "mock_access_token"
-        risco_cloud._site_id = "mock_site_id"
-        risco_cloud._session_id = "mock_session_id"
+    # Set the access token to avoid login
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
 
-        # Run the get_state method
-        state = await risco_cloud.get_state()
+    with self.assertRaises(OperationError):
+      # Run the get_state method
+      await risco_cloud.get_state()
 
-        # Check if the state is returned correctly
-        self.assertEqual(state.partitions, {})
-        self.assertEqual(state.zones, {})
+    # Check if the _site_post method was called three times
+    self.assertEqual(mock_authenticated_post.call_count, 3)
 
-        # Check if the _site_post method was called twice
-        self.assertEqual(mock_authenticated_post.call_count, 2)
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
+  async def test_get_state_with_fallback_to_cloud(self, mock_authenticated_post):
+    # Mock the _site_post method to raise RetryableOperationError for the first call
+    mock_authenticated_post.side_effect = [
+      RetryableOperationError("Retryable error"),
+      # Successful response on the second call with fallback to cloud
+      {
+        "state": {"partitions": [], "zones": [], "status": {}}
+      }
+    ]
 
-        # Check if the _site_post calls contain the correct from_control_panel value
-        self.assertTrue(mock_authenticated_post.call_args_list[0][0][1]['fromControlPanel'])
-        self.assertFalse(mock_authenticated_post.call_args_list[1][0][1]['fromControlPanel'])
+    # Create an instance of RiscoCloud
+    risco_cloud = RiscoCloud("username", "password", "pin", from_control_panel=True, fallback_to_cloud=True)
+
+    # Set the access token to avoid login
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+
+    # Run the get_state method
+    state = await risco_cloud.get_state()
+
+    # Check if the state is returned correctly
+    self.assertEqual(state.partitions, {})
+    self.assertEqual(state.zones, {})
+    self.assertFalse(state.is_from_control_panel)
+
+    # Check if the _site_post method was called twice
+    self.assertEqual(mock_authenticated_post.call_count, 2)
+
+    # Check if the _site_post calls contain the correct from_control_panel value
+    self.assertTrue(mock_authenticated_post.call_args_list[0][0][1]['fromControlPanel'])
+    self.assertFalse(mock_authenticated_post.call_args_list[1][0][1]['fromControlPanel'])
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()


### PR DESCRIPTION
For RiscoCloud:

RetryableOperationError idea/code took from https://github.com/OnFreund/pyrisco/pull/21

In order to support control panel disconnected from RiscoCloud, due to network or configuration issues, 2 parameters have been implemented:

* from_control_panel (default=True): force asking RiscoCloud to request your alarm's panel. Fails if it can't reach it after 3 retries.
* fallback_to_cloud (default=False): if first try returns a 72 error (see https://github.com/OnFreund/pyrisco/pull/21) then retry with from_control_panel=False a couple of times.

Additional Alarm `is_from_control_panel` property added to specify if data comes from Alarm's control panel or latest info from RiscoCloud.

Proxy support via `proxy` and `proxy_auth` parameters, see [aiohttp documentation](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support).

Additional modifications:
* RiscoCloud unit test
* RiscoCloud examples
