### PR TITLE
RiscoCloud: Add is_from_control_panel and automatic fallback to cloud

### DIFF
--- a/pyrisco/cloud/alarm.py
+++ b/pyrisco/cloud/alarm.py
@@ -4,12 +4,18 @@ from .zone import Zone
 class Alarm:
   """A representation of a Risco alarm system."""
 
-  def __init__(self, api, raw):
+  def __init__(self, api, raw, from_control_panel):
     """Read alarm from response."""
     self._api = api
     self._raw = raw
     self._partitions = None
     self._zones = None
+    self._from_control_panel = from_control_panel
+
+  @property
+  def is_from_control_panel(self):
+    """Is information coming from Control Panel via RiscoCloud."""
+    return self._from_control_panel
 
   @property
   def partitions(self):

--- a/pyrisco/cloud/alarm.py
+++ b/pyrisco/cloud/alarm.py
@@ -4,18 +4,18 @@ from .zone import Zone
 class Alarm:
   """A representation of a Risco alarm system."""
 
-  def __init__(self, api, raw, from_control_panel):
+  def __init__(self, api, raw, assumed_control_panel_state):
     """Read alarm from response."""
     self._api = api
     self._raw = raw
     self._partitions = None
     self._zones = None
-    self._from_control_panel = from_control_panel
+    self._assumed_control_panel_state = assumed_control_panel_state
 
   @property
-  def is_from_control_panel(self):
-    """Is information coming from Control Panel via RiscoCloud."""
-    return self._from_control_panel
+  def assumed_control_panel_state(self):
+    """Return True if the state is based on RiscoCloud instead of reading it from the control panel."""
+    return self._assumed_control_panel_state
 
   @property
   def partitions(self):

--- a/pyrisco/common.py
+++ b/pyrisco/common.py
@@ -143,3 +143,7 @@ class CannotConnectError(Exception):
 
 class OperationError(Exception):
   """Exception to indicate an error in operation."""
+
+
+class RetryableOperationError(OperationError):
+  """Exception to indicate an error in operation that can be retried and might succeed."""

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.6.5'
+VERSION = '0.6.6'
 
 REQUIRED = ['aiohttp']
 


### PR DESCRIPTION
rework of https://github.com/OnFreund/pyrisco/pull/30
using https://github.com/OnFreund/pyrisco/pull/21 from @gcacace for RetryableOperationError idea/code

* restore from_control_panel=True from version 0.6.4 
* add RetryableOperationError when code 72 is returned from RiscoCloud 
* switch to from_control_panel=False when RetryableOperationError is raised once
* set Alarm.is_from_control_panel flag according to _site_post's from_control_panel
* bump version to 0.6.6


