### PR TITLE
Add method to set the time of the panel.

### DIFF
--- a/pyrisco/local/risco_local.py
+++ b/pyrisco/local/risco_local.py
@@ -105,6 +105,11 @@ class RiscoLocal:
     if self.zones[zone_id].bypassed != bypass:
       await self._rs.send_ack_command(F'ZBYPAS={zone_id}')
 
+  async def set_time(self, time):
+    """Set the time of the panel."""
+    formatted_time = time.strftime('%d/%m/%Y %H:%M')
+    await self._rs.send_ack_command(F'CLOCK={formatted_time}')
+
   def _add_handler(handlers, handler):
     handlers.append(handler)
     def _remove():


### PR DESCRIPTION
Hi,

I'm creating this PR to add a method to set the time of the panel on a local connection.
The panel I have only allows one connection so it doesn't seem to be able to sync the time with a timeserver although it is configured to do so. Over a few weeks time there is a drift of 8 minutes between the current time and the time of the panel.
I've tested it on my own panel which is a LightSys (paneltype RP432).

The idea would be to create a service in the HA integration that can be used in an automation so the user can update the time of the panel at the preferred interval.

You can test it yourself with this script:

```python
import asyncio
import datetime

from pyrisco import RiscoLocal

async def test_risco():
    r = RiscoLocal("192.168.X.X", 1000, "XXXX")

    await r.connect()

    await r.set_time(datetime.datetime.now())
    #await r.set_clock(datetime.datetime(2025, 2, 7, 14, 30, 0))

    await r.disconnect()

if __name__ == '__main__':
    asyncio.run(test_risco())

```

Happy to hear what you think of it.