### PR TITLE
Add User-Agent header to cloud requests

### DIFF
--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -42,7 +42,8 @@ class RiscoCloud:
   async def _authenticated_post(self, url, body):
     headers = {
       "Content-Type": "application/json",
-      "authorization": "Bearer " + self._access_token,
+      "authorization": f"Bearer {self._access_token}",
+      "User-Agent": "pyrisco/1.0",
     }
     async with self._session.post(url, headers=headers, json=body) as resp:
       json = await resp.json()
@@ -81,7 +82,7 @@ class RiscoCloud:
           await self.login()
 
   async def _login_user_pass(self):
-    headers = {"Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", "User-Agent": "pyrisco/1.0"}
     body = {"userName": self._username, "password": self._password}
     try:
       async with self._session.post(

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -42,7 +42,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(risco_cloud._access_token, "mock_access_token")
     mock_session.post.assert_called_with(
       LOGIN_URL,
-      headers={"Content-Type": "application/json"},
+      headers={"Content-Type": "application/json", "User-Agent": "pyrisco/1.0"},
       json={"userName": "username", "password": "password"}
     )
     mock_authenticated_post.assert_called()
@@ -72,7 +72,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     mock_session.post.assert_called_with(
       LOGIN_URL,
-      headers={"Content-Type": "application/json"},
+      headers={"Content-Type": "application/json", "User-Agent": "pyrisco/1.0"},
       json={"userName": "username", "password": "password"}
     )
 


### PR DESCRIPTION
This is a workaround because Risco is currently [blocking the HomeAssistant user agent](https://github.com/home-assistant/core/issues/167776)