### PR TITLE
Add SSE push subscription to RiscoCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,50 @@ You can install pyrisco from [PyPI](https://pypi.org/project/pyrisco/):
 
     pip3 install pyrisco
 
-Python 3.7 and above are supported.
+Python 3.11 and above are supported.
 
 
 ## How to use
 
 ### Cloud
 
-#### RiscoCloud fallback mode
+#### Push updates via SSE (recommended)
 
-Pyrisco will instruct RiscoCloud to request updates from your control panel, if there is an issue RiscoCloud will return a 72 error code, if this happens,
-* pyrisco will try a second time in fallback mode, which will request the last known state from RiscoCloud.
-* A flag named `assumed_control_panel_state` will be set to True on the Alarm object to indicate that the state is assumed, rather than obtained from the panel. **Assumed states could be stale.**
+Pyrisco can subscribe to Risco Cloud's Server-Sent Events stream and push state changes to your callbacks as they happen, without polling.
 
-### Example
+```python
+import asyncio
+from pyrisco import RiscoCloud
+
+r = RiscoCloud("<username>", "<password>", "<pincode>")
+
+async def on_state(alarm):
+    print(alarm.partitions[0].armed)
+    print(alarm.zones[0].triggered)
+
+async def on_error(error):
+    print(f"SSE error: {error}, reconnecting in 5s...")
+    await asyncio.sleep(5)
+    await r.login()
+    await r.subscribe_states()
+
+async def main():
+    await r.login()
+    r.add_state_handler(on_state)
+    r.add_error_handler(on_error)
+    await r.subscribe_states()
+    await asyncio.Future()  # run forever
+
+asyncio.run(main())
+```
+
+Both `add_state_handler` and `add_error_handler` return a callable that removes the handler when called.
+
+After `subscribe_states()` is started, calls to `get_state()` return the latest cached state without making a network request.
+
+#### Polling
+
+You can also poll for state manually:
 
 ```python
 import asyncio
@@ -62,6 +92,12 @@ async def test_cloud():
 
 asyncio.run(test_cloud())
 ```
+
+#### RiscoCloud fallback mode
+
+Pyrisco will instruct RiscoCloud to request updates from your control panel, if there is an issue RiscoCloud will return a 72 error code, if this happens,
+* pyrisco will try a second time in fallback mode, which will request the last known state from RiscoCloud.
+* A flag named `assumed_control_panel_state` will be set to True on the Alarm object to indicate that the state is assumed, rather than obtained from the panel. **Assumed states could be stale.**
 
 
 ### Local

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -1,0 +1,30 @@
+import asyncio
+from pyrisco import RiscoCloud
+
+risco = RiscoCloud("user@example.com", "password", "1234")
+
+
+async def on_state(alarm):
+    print("State update received")
+    for partition_id, partition in alarm.partitions.items():
+        print(f"  Partition {partition_id}: armed={partition.armed}, triggered={partition.triggered}")
+    for zone_id, zone in alarm.zones.items():
+        print(f"  Zone {zone_id} ({zone.name}): triggered={zone.triggered}, bypassed={zone.bypassed}")
+
+
+async def on_error(error):
+    print(f"SSE error: {error}, reconnecting in 5s...")
+    await asyncio.sleep(5)
+    await risco.login()
+    await risco.subscribe_states()
+
+
+async def main():
+    await risco.login()
+    risco.add_state_handler(on_state)
+    risco.add_error_handler(on_error)
+    await risco.subscribe_states()
+    await asyncio.Future()  # run forever
+
+
+asyncio.run(main())

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -2,6 +2,8 @@
 
 import aiohttp
 import asyncio
+import json
+from datetime import datetime
 
 from .alarm import Alarm
 from .event import Event
@@ -17,6 +19,7 @@ EVENTS_URL = (
   "https://www.riscocloud.com/webapi/api/wuws/site/%s/ControlPanel/GetEventLog"
 )
 BYPASS_URL = "https://www.riscocloud.com/webapi/api/wuws/site/%s/ControlPanel/SetZoneBypassStatus"
+SSE_URL = "https://www.riscocloud.com/webapi/api/wuws/site/%s/ControlPanel/sse/connect"
 
 NUM_RETRIES = 3
 RETRYABLE_RESULT_CODE = 72
@@ -38,6 +41,18 @@ class RiscoCloud:
     self._site_uuid = None
     self._session = None
     self._created_session = False
+    self._state_handlers = []
+    self._error_handlers = []
+    self._last_status_update = None
+    self._latest_state = None
+    self._subscription_task = None
+
+  @staticmethod
+  def _add_handler(handlers, handler):
+    handlers.append(handler)
+    def _remove():
+      handlers.remove(handler)
+    return _remove
 
   async def _authenticated_post(self, url, body):
     headers = {
@@ -46,18 +61,18 @@ class RiscoCloud:
       "User-Agent": "pyrisco/1.0",
     }
     async with self._session.post(url, headers=headers, json=body) as resp:
-      json = await resp.json()
+      json_resp = await resp.json()
 
-    if json["status"] == 401:
-      raise UnauthorizedError(json["errorText"])
+    if json_resp["status"] == 401:
+      raise UnauthorizedError(json_resp["errorText"])
 
-    if "result" in json and json["result"] == RETRYABLE_RESULT_CODE:
-      raise RetryableOperationError(str(json))
+    if "result" in json_resp and json_resp["result"] == RETRYABLE_RESULT_CODE:
+      raise RetryableOperationError(str(json_resp))
 
-    if "result" in json and json["result"] != 0:
-      raise OperationError(str(json))
+    if "result" in json_resp and json_resp["result"] != 0:
+      raise OperationError(str(json_resp))
 
-    return json["response"]
+    return json_resp["response"]
 
   async def _site_post(self, url, body):
     site_url = url % self._site_id
@@ -88,10 +103,10 @@ class RiscoCloud:
       async with self._session.post(
         LOGIN_URL, headers=headers, json=body
       ) as resp:
-        json = await resp.json()
-        if json["status"] == 401:
+        json_resp = await resp.json()
+        if json_resp["status"] == 401:
           raise UnauthorizedError("Invalid username or password")
-        self._access_token = json["response"].get("accessToken")
+        self._access_token = json_resp["response"].get("accessToken")
     except aiohttp.client_exceptions.ClientConnectorError as e:
       raise CannotConnectError from e
 
@@ -123,10 +138,60 @@ class RiscoCloud:
     resp, assumed_control_panel_state = await self._site_post(CONTROL_URL, body)
     return Alarm(self, resp, assumed_control_panel_state)
 
+  async def _sse_loop(self):
+    try:
+      url = SSE_URL % self._site_id
+      headers = {
+        "authorization": f"Bearer {self._access_token}",
+        "User-Agent": "pyrisco/1.0",
+      }
+      params = {"sessionToken": self._session_id}
+      async with self._session.get(url, headers=headers, params=params) as resp:
+        event_type = None
+        data_line = None
+        async for line_bytes in resp.content:
+          line = line_bytes.decode("utf-8").rstrip("\r\n")
+          if line.startswith("event:"):
+            event_type = line[6:].strip()
+          elif line.startswith("data:"):
+            data_line = line[5:].strip()
+          elif line == "" and event_type == "runtimeUpdate" and data_line:
+            await self._handle_runtime_update(json.loads(data_line))
+            event_type = None
+            data_line = None
+    except asyncio.CancelledError:
+      raise
+    except Exception as e:
+      for handler in list(self._error_handlers):
+        await handler(e)
+
+  async def _handle_runtime_update(self, data):
+    if data.get("isOffline"):
+      return
+    ts_str = data.get("lastStatusUpdate")
+    if not ts_str:
+      return
+    update_time = datetime.fromisoformat(ts_str)
+    if self._last_status_update is not None and update_time <= self._last_status_update:
+      return
+    resp, assumed = await self._site_post(STATE_URL, {})
+    alarm = Alarm(self, resp["state"]["status"], assumed)
+    self._last_status_update = update_time
+    self._latest_state = alarm
+    for handler in list(self._state_handlers):
+      await handler(alarm)
+
   async def close(self):
     """Close the connection."""
     self._session_id = None
-    if self._created_session == True and self._session is not None:
+    if self._subscription_task:
+      self._subscription_task.cancel()
+      try:
+        await self._subscription_task
+      except (asyncio.CancelledError, Exception):
+        pass
+      self._subscription_task = None
+    if self._created_session and self._session is not None:
       await self._session.close()
       self._session = None
       self._created_session = False
@@ -141,8 +206,22 @@ class RiscoCloud:
     await self._login_site()
     await self._login_session()
 
+  def add_state_handler(self, handler):
+    """Register an async callback for state updates. Returns a remover callable."""
+    return RiscoCloud._add_handler(self._state_handlers, handler)
+
+  def add_error_handler(self, handler):
+    """Register an async callback for SSE errors. Returns a remover callable."""
+    return RiscoCloud._add_handler(self._error_handlers, handler)
+
+  async def subscribe_states(self):
+    """Start listening for push state updates via SSE."""
+    self._subscription_task = asyncio.create_task(self._sse_loop())
+
   async def get_state(self):
     """Get partitions and zones."""
+    if self._latest_state is not None:
+      return self._latest_state
     resp, assumed_control_panel_state = await self._site_post(STATE_URL, {})
     return Alarm(self, resp["state"]["status"], assumed_control_panel_state)
 

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -144,6 +144,7 @@ class RiscoCloud:
       headers = {
         "authorization": f"Bearer {self._access_token}",
         "User-Agent": "pyrisco/1.0",
+        "sessionToken": self._session_id,
       }
       params = {"sessionToken": self._session_id}
       async with self._session.get(url, headers=headers, params=params) as resp:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DESCRIPTION = 'A python library to communicate with Risco Cloud.'
 URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
-REQUIRES_PYTHON = '>=3.7.0'
+REQUIRES_PYTHON = '>=3.11.0'
 VERSION = '0.6.8'
 
 REQUIRED = ['aiohttp']
@@ -110,7 +110,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/PyRisco'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.11.0'
-VERSION = '0.6.8'
+VERSION = '0.7.0'
 
 REQUIRED = ['aiohttp']
 

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -1,8 +1,30 @@
+import asyncio
 import unittest
-from unittest.mock import patch, AsyncMock
+from datetime import datetime, timezone
+from unittest.mock import patch, AsyncMock, MagicMock
 from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError
+from pyrisco.cloud.alarm import Alarm
 
 LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
+
+
+def _make_sse_stream(*events):
+  """Build an async iterator that yields SSE lines for the given events.
+
+  Each event is a (event_type, data_dict) tuple.
+  """
+  lines = []
+  for event_type, data in events:
+    import json as _json
+    lines.append(f"event: {event_type}\r\n".encode())
+    lines.append(f"data: {_json.dumps(data)}\r\n".encode())
+    lines.append(b"\r\n")
+
+  async def _iter():
+    for line in lines:
+      yield line
+
+  return _iter()
 
 
 class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
@@ -182,6 +204,140 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(mock_authenticated_post.call_count, 2)
     self.assertTrue(mock_authenticated_post.call_args_list[0][0][1]['fromControlPanel'])
     self.assertFalse(mock_authenticated_post.call_args_list[1][0][1]['fromControlPanel'])
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_calls_handler(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received = []
+    async def on_state(alarm):
+      received.append(alarm)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_state_handler(on_state)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received), 1)
+    self.assertIsInstance(received[0], Alarm)
+    self.assertEqual(mock_site_post.call_count, 1)
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_no_update_same_timestamp(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
+      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(mock_site_post.call_count, 1)
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  async def test_get_state_returns_cached(self, mock_site_post):
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+
+    cached_alarm = Alarm(risco_cloud, {"partitions": [], "zones": []}, False)
+    risco_cloud._latest_state = cached_alarm
+
+    result = await risco_cloud.get_state()
+
+    self.assertIs(result, cached_alarm)
+    mock_site_post.assert_not_called()
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_skips_fetch_when_offline(self, MockClientSession, mock_site_post):
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z", "isOffline": True}),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    mock_site_post.assert_not_called()
+
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_calls_error_handler(self, MockClientSession):
+    mock_session = MockClientSession.return_value
+    error = RuntimeError("stream broken")
+
+    async def _failing_content():
+      raise error
+      yield  # make it an async generator
+
+    mock_resp = MagicMock()
+    mock_resp.content = _failing_content()
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received_errors = []
+    async def on_error(err):
+      received_errors.append(err)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_error_handler(on_error)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received_errors), 1)
+    self.assertIs(received_errors[0], error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Adds `subscribe_states()` which connects to Risco Cloud's SSE endpoint (`/ControlPanel/sse/connect`) and pushes state changes via async callbacks, replacing the need to poll `get_state()` in a loop
- Adds `add_state_handler(handler)` and `add_error_handler(handler)` — both return a remover callable (mirrors the `RiscoLocal` pattern)
- `runtimeUpdate` events with `isOffline: true` or a non-advancing `lastStatusUpdate` timestamp are ignored without fetching state
- `get_state()` returns the latest cached state when a subscription is active, preserving backwards compatibility
- `close()` cancels the background SSE task before closing the session
- Bumps minimum Python version to 3.11 (required for `datetime.fromisoformat()` to handle the `Z` suffix natively)

## Test plan

- [ ] `python -m pytest tests/test_risco_cloud.py -v` — all 12 tests pass
- [ ] Handler called on new `lastStatusUpdate` timestamp
- [ ] Duplicate timestamp skipped (no extra network call)
- [ ] `isOffline: true` skipped (no network call)
- [ ] `get_state()` returns cached state without hitting the network after subscription starts
- [ ] Error handler called when SSE stream raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)