### PR TITLE
Add automated test build publishing for pull requests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,8 +26,10 @@ jobs:
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0.dev${{ github.event.pull_request.number }}
 
-      - name: Save PR number
-        run: echo "${{ github.event.pull_request.number }}" > dist/PR_NUMBER
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > dist/PR_NUMBER
+          echo "${{ github.event.pull_request.head.sha }}" > dist/PR_HEAD_SHA
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,6 +8,10 @@ concurrency:
   group: pr-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     name: Build PR wheel
@@ -22,7 +26,7 @@ jobs:
       - run: pip install build
 
       - name: Build wheel
-        run: python -m build
+        run: python -m build --wheel
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0.dev${{ github.event.pull_request.number }}
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,35 @@
+name: PR Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build PR wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.x"
+
+      - run: pip install build
+
+      - name: Build wheel
+        run: python -m build
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0.dev${{ github.event.pull_request.number }}
+
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > dist/PR_NUMBER
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: pr-wheel
+          path: dist/

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -22,10 +22,9 @@ jobs:
 
       - name: Delete PR comment
         run: |
-          EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR}/comments" \
+          gh api "repos/${GH_REPO}/issues/${PR}/comments" \
             --paginate \
             --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
-            | head -1)
-          if [ -n "$EXISTING" ]; then
-            gh api "repos/${GH_REPO}/issues/comments/${EXISTING}" -X DELETE
-          fi
+            | while read -r ID; do
+              gh api "repos/${GH_REPO}/issues/comments/${ID}" -X DELETE
+            done

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,29 @@
+name: PR Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  cleanup:
+    name: Delete PR pre-release
+    runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Delete PR release and tag
+        run: gh release delete "pr-${PR}" --cleanup-tag --yes || true
+
+      - name: Delete PR comment
+        run: |
+          EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR}/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- pr-test-build -->"))] | first | .id // empty')
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${GH_REPO}/issues/comments/${EXISTING}" -X DELETE
+          fi

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Delete PR comment
         run: |
           EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR}/comments" \
-            --jq '[.[] | select(.body | startswith("<!-- pr-test-build -->"))] | first | .id // empty')
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
+            | head -1)
           if [ -n "$EXISTING" ]; then
             gh api "repos/${GH_REPO}/issues/comments/${EXISTING}" -X DELETE
           fi

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           EXISTING=$(gh api "repos/${GH_REPO}/issues/${PR}/comments" \
             --paginate \
-            --jq '.[] | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
             | head -1)
           if [ -n "$EXISTING" ]; then
             gh api "repos/${GH_REPO}/issues/comments/${EXISTING}" -X DELETE

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -63,18 +63,22 @@ jobs:
             exit 0
           fi
 
-          gh pr comment "$PR" --repo "$REPO" --body "<!-- pr-test-build -->
-## Test build ready
-
-**pip:**
-\`\`\`
-pip install ${WHEEL_URL}
-\`\`\`
-
-**Home Assistant** — temporarily update your integration's \`manifest.json\`:
-\`\`\`json
-\"requirements\": [\"pyrisco @ ${WHEEL_URL}\"]
-\`\`\`
-Revert to the pinned version after testing."
+          BODY_FILE=$(mktemp)
+          printf '%s\n' \
+            '<!-- pr-test-build -->' \
+            '## Test build ready' \
+            '' \
+            '**pip:**' \
+            '```' \
+            "pip install ${WHEEL_URL}" \
+            '```' \
+            '' \
+            "**Home Assistant** — temporarily update your integration's \`manifest.json\`:" \
+            '```json' \
+            "\"requirements\": [\"pyrisco @ ${WHEEL_URL}\"]" \
+            '```' \
+            'Revert to the pinned version after testing.' \
+            > "$BODY_FILE"
+          gh pr comment "$PR" --repo "$REPO" --body-file "$BODY_FILE"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -4,9 +4,14 @@ on:
   workflow_run:
     workflows: ["PR Build"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'PR Build run ID to publish (find it in the Actions URL)'
+        required: true
 
 concurrency:
-  group: pr-publish-${{ github.event.workflow_run.id }}
+  group: pr-publish-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
 
 permissions:
   contents: write
@@ -17,12 +22,23 @@ jobs:
   publish:
     name: Publish PR pre-release
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Resolve run ID
+        id: run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "id=${{ github.event.inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: pr-wheel
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.run.outputs.id }}
           github-token: ${{ github.token }}
           path: dist/
 

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
   actions: read
 
 jobs:

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Post PR comment (first build only)
         run: |
           PR="${{ steps.pr.outputs.number }}"
-          VERSION="0.0.0.dev${PR}"
           TAG="pr-${PR}"
           REPO="${{ github.repository }}"
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
@@ -91,7 +90,7 @@ jobs:
 
           EXISTING=$(gh api "repos/${REPO}/issues/${PR}/comments" \
             --paginate \
-            --jq '.[] | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
             | head -1)
 
           if [ -n "$EXISTING" ]; then

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -50,6 +50,19 @@ jobs:
           echo "number=$(cat dist/PR_NUMBER)" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(cat dist/PR_HEAD_SHA)" >> "$GITHUB_OUTPUT"
 
+      - name: Validate wheel
+        id: wheel
+        run: |
+          PR="$(cat dist/PR_NUMBER)"
+          WHL_COUNT=$(ls dist/pyrisco-0.0.0.dev${PR}-*.whl 2>/dev/null | wc -l)
+          if [ "$WHL_COUNT" -ne 1 ]; then
+            echo "Expected exactly 1 wheel matching pyrisco-0.0.0.dev${PR}-*.whl, found ${WHL_COUNT}:"
+            ls dist/ || true
+            exit 1
+          fi
+          WHEEL_FILE=$(ls dist/pyrisco-0.0.0.dev${PR}-*.whl)
+          echo "basename=$(basename "$WHEEL_FILE")" >> "$GITHUB_OUTPUT"
+
       - name: Delete existing PR release (if any)
         run: gh release delete "pr-${{ steps.pr.outputs.number }}" --cleanup-tag --yes || true
         env:
@@ -74,8 +87,7 @@ jobs:
           TAG="pr-${PR}"
           REPO="${{ github.repository }}"
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
-          WHEEL_BASENAME=$(basename dist/*.whl)
-          WHEEL_URL="${BASE}/${WHEEL_BASENAME}"
+          WHEEL_URL="${BASE}/${{ steps.wheel.outputs.basename }}"
 
           EXISTING=$(gh api "repos/${REPO}/issues/${PR}/comments" \
             --paginate \

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -111,7 +111,9 @@ jobs:
             '' \
             "**Home Assistant** — temporarily update your integration's \`manifest.json\`:" \
             '```json' \
-            "\"requirements\": [\"pyrisco @ ${WHEEL_URL}\"]" \
+            '{' \
+            "  \"requirements\": [\"pyrisco @ ${WHEEL_URL}\"]" \
+            '}' \
             '```' \
             'Revert to the pinned version after testing.' \
             > "$BODY_FILE"

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create GitHub pre-release
         run: |
-          gh release create "pr-${{ steps.pr.outputs.number }}" dist/*.whl \
+          gh release create "pr-${{ steps.pr.outputs.number }}" "dist/${{ steps.wheel.outputs.basename }}" \
             --prerelease \
             --target "${{ steps.pr.outputs.head_sha }}" \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -11,7 +11,8 @@ on:
         required: true
 
 concurrency:
-  group: pr-publish-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+  group: pr-publish-${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.run_id || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -43,9 +44,11 @@ jobs:
           github-token: ${{ github.token }}
           path: dist/
 
-      - name: Read PR number
+      - name: Read PR metadata
         id: pr
-        run: echo "number=$(cat dist/PR_NUMBER)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "number=$(cat dist/PR_NUMBER)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(cat dist/PR_HEAD_SHA)" >> "$GITHUB_OUTPUT"
 
       - name: Delete existing PR release (if any)
         run: gh release delete "pr-${{ steps.pr.outputs.number }}" --cleanup-tag --yes || true
@@ -57,6 +60,7 @@ jobs:
         run: |
           gh release create "pr-${{ steps.pr.outputs.number }}" dist/*.whl \
             --prerelease \
+            --target "${{ steps.pr.outputs.head_sha }}" \
             --repo "${{ github.repository }}" \
             --title "PR #${{ steps.pr.outputs.number }} test build" \
             --notes "Test build for PR #${{ steps.pr.outputs.number }}."
@@ -70,10 +74,13 @@ jobs:
           TAG="pr-${PR}"
           REPO="${{ github.repository }}"
           BASE="https://github.com/${REPO}/releases/download/${TAG}"
-          WHEEL_URL="${BASE}/pyrisco-${VERSION}-py3-none-any.whl"
+          WHEEL_BASENAME=$(basename dist/*.whl)
+          WHEEL_URL="${BASE}/${WHEEL_BASENAME}"
 
           EXISTING=$(gh api "repos/${REPO}/issues/${PR}/comments" \
-            --jq '[.[] | select(.body | startswith("<!-- pr-test-build -->"))] | first | .id // empty')
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- pr-test-build -->")) | .id' \
+            | head -1)
 
           if [ -n "$EXISTING" ]; then
             echo "Comment already exists, skipping."

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,0 +1,80 @@
+name: PR Publish
+
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
+
+concurrency:
+  group: pr-publish-${{ github.event.workflow_run.id }}
+
+permissions:
+  contents: write
+  issues: write
+  actions: read
+
+jobs:
+  publish:
+    name: Publish PR pre-release
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: pr-wheel
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: dist/
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat dist/PR_NUMBER)" >> "$GITHUB_OUTPUT"
+
+      - name: Delete existing PR release (if any)
+        run: gh release delete "pr-${{ steps.pr.outputs.number }}" --cleanup-tag --yes || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: Create GitHub pre-release
+        run: |
+          gh release create "pr-${{ steps.pr.outputs.number }}" dist/*.whl \
+            --prerelease \
+            --repo "${{ github.repository }}" \
+            --title "PR #${{ steps.pr.outputs.number }} test build" \
+            --notes "Test build for PR #${{ steps.pr.outputs.number }}."
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Post PR comment (first build only)
+        run: |
+          PR="${{ steps.pr.outputs.number }}"
+          VERSION="0.0.0.dev${PR}"
+          TAG="pr-${PR}"
+          REPO="${{ github.repository }}"
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+          WHEEL_URL="${BASE}/pyrisco-${VERSION}-py3-none-any.whl"
+
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR}/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- pr-test-build -->"))] | first | .id // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Comment already exists, skipping."
+            exit 0
+          fi
+
+          gh pr comment "$PR" --repo "$REPO" --body "<!-- pr-test-build -->
+## Test build ready
+
+**pip:**
+\`\`\`
+pip install ${WHEEL_URL}
+\`\`\`
+
+**Home Assistant** — temporarily update your integration's \`manifest.json\`:
+\`\`\`json
+\"requirements\": [\"pyrisco @ ${WHEEL_URL}\"]
+\`\`\`
+Revert to the pinned version after testing."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ pip install https://github.com/OnFreund/pyrisco/releases/download/pr-42/pyrisco-
 
 **Home Assistant** — temporarily update your integration's `manifest.json` to use the PEP 508 URL form so HA doesn't overwrite it on restart:
 ```json
-"requirements": ["pyrisco @ https://github.com/OnFreund/pyrisco/releases/download/pr-42/pyrisco-0.0.0.dev42-py3-none-any.whl"]
+{
+  "requirements": ["pyrisco @ https://github.com/OnFreund/pyrisco/releases/download/pr-42/pyrisco-0.0.0.dev42-py3-none-any.whl"]
+}
 ```
 Replace `42` with the actual PR number. Revert to the pinned version (e.g. `pyrisco==0.7.1`) after testing.
 

--- a/README.md
+++ b/README.md
@@ -157,3 +157,22 @@ async def test_local():
 
 asyncio.run(test_local())
 ```
+
+## Testing PRs
+
+Every pull request automatically publishes a test build as a GitHub pre-release. You can find the install command in the PR comment posted by the bot, or on the [Releases page](https://github.com/OnFreund/pyrisco/releases) (pre-releases are tagged `pr-{number}`).
+
+**pip:**
+```
+pip install https://github.com/OnFreund/pyrisco/releases/download/pr-42/pyrisco-0.0.0.dev42-py3-none-any.whl
+```
+
+**Home Assistant** — temporarily update your integration's `manifest.json` to use the PEP 508 URL form so HA doesn't overwrite it on restart:
+```json
+"requirements": ["pyrisco @ https://github.com/OnFreund/pyrisco/releases/download/pr-42/pyrisco-0.0.0.dev42-py3-none-any.whl"]
+```
+Replace `42` with the actual PR number. Revert to the pinned version (e.g. `pyrisco==0.7.1`) after testing.
+
+The install URL is stable for the lifetime of the PR — new commits to the same PR reuse the same tag and wheel name, so you don't need to update `manifest.json` if more commits are pushed.
+
+The pre-release and comment are deleted automatically when the PR is merged or closed.


### PR DESCRIPTION
## Summary

This PR adds a complete CI/CD workflow for automatically building and publishing test wheels for pull requests, making it easier for users to test changes before they're merged.

## Key Changes

- **`pr-build.yml`** — New workflow that triggers on PR open/update/reopen. Builds a wheel with a dev version number based on the PR number (`0.0.0.dev{PR_NUMBER}`) and uploads it as an artifact.

- **`pr-publish.yml`** — New workflow triggered after `pr-build` succeeds. Downloads the built wheel, creates a GitHub pre-release tagged `pr-{number}`, and posts a comment on the PR with installation instructions for both pip and Home Assistant users. Deletes any existing pre-release for the same PR to keep the release URL stable across commits.

- **`pr-cleanup.yml`** — New workflow triggered when a PR is closed or merged. Cleans up the pre-release, tag, and bot comment automatically.

- **`README.md`** — Added "Testing PRs" section documenting how to install test builds from PR pre-releases, with examples for both pip and Home Assistant manifest.json usage.

## Implementation Details

- Uses `setuptools-scm` to generate version strings dynamically via the `SETUPTOOLS_SCM_PRETEND_VERSION` environment variable, avoiding the need to modify source files.
- Pre-release URLs are stable for the lifetime of a PR — new commits reuse the same tag and wheel filename, so users don't need to update their manifest.json.
- The bot comment is only posted on the first build of a PR (checked via comment body marker `<!-- pr-test-build -->`); subsequent commits reuse the same release without duplicate comments.
- Uses concurrency groups to cancel in-progress builds when new commits are pushed to the same PR.

https://claude.ai/code/session_01JSncdXk24DcCq27NpZHB67