### PR TITLE
Fix SSE field casing and add event handler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pyrisco can subscribe to Risco Cloud's Server-Sent Events stream and push state 
 
 ```python
 import asyncio
-from pyrisco import RiscoCloud
+from pyrisco import RiscoCloud, MaxRetriesError
 
 r = RiscoCloud("<username>", "<password>", "<pincode>")
 
@@ -29,15 +29,23 @@ async def on_state(alarm):
     print(alarm.partitions[0].armed)
     print(alarm.zones[0].triggered)
 
+async def on_event(events):
+    for event in events:
+        print(event.text)
+
 async def on_error(error):
-    print(f"SSE error: {error}, reconnecting in 5s...")
-    await asyncio.sleep(5)
-    await r.login()
-    await r.subscribe_states()
+    if isinstance(error, MaxRetriesError):
+        # All reconnect attempts exhausted — re-login and re-subscribe
+        await r.login()
+        await r.subscribe_states()
+    else:
+        # Transient error — pyrisco will reconnect automatically with backoff
+        print(f"SSE error: {error}")
 
 async def main():
     await r.login()
     r.add_state_handler(on_state)
+    r.add_event_handler(on_event)
     r.add_error_handler(on_error)
     await r.subscribe_states()
     await asyncio.Future()  # run forever
@@ -45,9 +53,11 @@ async def main():
 asyncio.run(main())
 ```
 
-Both `add_state_handler` and `add_error_handler` return a callable that removes the handler when called.
+`add_state_handler`, `add_event_handler`, and `add_error_handler` each return a callable that removes the handler when called.
 
-After `subscribe_states()` is started, calls to `get_state()` return the latest cached state without making a network request.
+On connection errors pyrisco reconnects automatically with exponential backoff (1 s, 2 s, 4 s, 8 s…). After the maximum number of attempts the error handler is called with a `MaxRetriesError` wrapping the last exception — the recommended response is to re-login and re-subscribe.
+
+After `subscribe_states()` is started, the state handler is called immediately with the current state, and subsequent calls to `get_state()` return the latest cached state without making a network request.
 
 #### Polling
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ async def _restart():
 
 async def on_error(error):
     if isinstance(error, MaxRetriesError):
-        # Schedule restart outside the SSE task — calling close() from within
-        # the task would cancel it before login() could complete
+        # Schedule restart in a new task — calling close() from within the SSE
+        # task would deadlock because close() awaits the task itself
         asyncio.create_task(_restart())
     else:
         # Transient error — pyrisco will reconnect automatically with backoff

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ async def on_event(events):
     for event in events:
         print(event.text)
 
+async def _restart():
+    await r.close()
+    await r.login()
+    await r.subscribe_states()
+
 async def on_error(error):
     if isinstance(error, MaxRetriesError):
-        # All reconnect attempts exhausted — re-login and re-subscribe
-        await r.login()
-        await r.subscribe_states()
+        # Schedule restart outside the SSE task — calling close() from within
+        # the task would cancel it before login() could complete
+        asyncio.create_task(_restart())
     else:
         # Transient error — pyrisco will reconnect automatically with backoff
         print(f"SSE error: {error}")

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -1,5 +1,5 @@
 import asyncio
-from pyrisco import RiscoCloud
+from pyrisco import RiscoCloud, MaxRetriesError
 
 risco = RiscoCloud("user@example.com", "password", "1234")
 
@@ -19,7 +19,14 @@ async def on_event(events):
 
 
 async def on_error(error):
-    print(f"SSE error: {error} (will reconnect automatically)")
+    if isinstance(error, MaxRetriesError):
+        # All reconnect attempts exhausted — re-login and re-subscribe
+        print(f"Gave up reconnecting ({error.last_error}), re-logging in...")
+        await risco.login()
+        await risco.subscribe_states()
+    else:
+        # Transient error — pyrisco will reconnect automatically with backoff
+        print(f"SSE error: {error} (reconnecting automatically)")
 
 
 async def main():

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -19,10 +19,7 @@ async def on_event(events):
 
 
 async def on_error(error):
-    print(f"SSE error: {error}, reconnecting in 5s...")
-    await asyncio.sleep(5)
-    await risco.login()
-    await risco.subscribe_states()
+    print(f"SSE error: {error} (will reconnect automatically)")
 
 
 async def main():

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -12,6 +12,12 @@ async def on_state(alarm):
         print(f"  Zone {zone_id} ({zone.name}): triggered={zone.triggered}, bypassed={zone.bypassed}")
 
 
+async def on_event(events):
+    print(f"Received {len(events)} new event(s)")
+    for event in events:
+        print(f"  [{event.time}] {event.text}")
+
+
 async def on_error(error):
     print(f"SSE error: {error}, reconnecting in 5s...")
     await asyncio.sleep(5)
@@ -22,6 +28,7 @@ async def on_error(error):
 async def main():
     await risco.login()
     risco.add_state_handler(on_state)
+    risco.add_event_handler(on_event)
     risco.add_error_handler(on_error)
     await risco.subscribe_states()
     await asyncio.Future()  # run forever

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -27,8 +27,9 @@ async def _restart():
 
 async def on_error(error):
     if isinstance(error, MaxRetriesError):
-        # All reconnect attempts exhausted — schedule a fresh login outside the
-        # current SSE task (calling close() from within the task would cancel it)
+        # All reconnect attempts exhausted — schedule restart in a new task;
+        # calling close() from within the SSE task would deadlock because
+        # close() awaits the task itself
         print(f"Gave up reconnecting ({error.last_error}), restarting...")
         asyncio.create_task(_restart())
     else:

--- a/examples/cloud/cloud_sse_example.py
+++ b/examples/cloud/cloud_sse_example.py
@@ -18,12 +18,19 @@ async def on_event(events):
         print(f"  [{event.time}] {event.text}")
 
 
+async def _restart():
+    """Re-login and re-subscribe after all reconnect attempts are exhausted."""
+    await risco.close()
+    await risco.login()
+    await risco.subscribe_states()
+
+
 async def on_error(error):
     if isinstance(error, MaxRetriesError):
-        # All reconnect attempts exhausted — re-login and re-subscribe
-        print(f"Gave up reconnecting ({error.last_error}), re-logging in...")
-        await risco.login()
-        await risco.subscribe_states()
+        # All reconnect attempts exhausted — schedule a fresh login outside the
+        # current SSE task (calling close() from within the task would cancel it)
+        print(f"Gave up reconnecting ({error.last_error}), restarting...")
+        asyncio.create_task(_restart())
     else:
         # Transient error — pyrisco will reconnect automatically with backoff
         print(f"SSE error: {error} (reconnecting automatically)")

--- a/pyrisco/__init__.py
+++ b/pyrisco/__init__.py
@@ -1,3 +1,3 @@
 from pyrisco.local import RiscoLocal
 from pyrisco.cloud import RiscoCloud
-from .common import CannotConnectError, OperationError, UnauthorizedError
+from .common import CannotConnectError, OperationError, UnauthorizedError, MaxRetriesError

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -172,17 +172,15 @@ class RiscoCloud:
     if data.get("IsOffline"):
       return
     ts_str = data.get("LastStatusUpdate")
-    if not ts_str:
-      return
-    update_time = datetime.fromisoformat(ts_str)
-    if self._last_status_update is not None and update_time <= self._last_status_update:
-      return
-    resp, assumed = await self._site_post(STATE_URL, {})
-    alarm = Alarm(self, resp["state"]["status"], assumed)
-    self._last_status_update = update_time
-    self._latest_state = alarm
-    for handler in list(self._state_handlers):
-      await handler(alarm)
+    if ts_str:
+      update_time = datetime.fromisoformat(ts_str)
+      if self._last_status_update is None or update_time > self._last_status_update:
+        resp, assumed = await self._site_post(STATE_URL, {})
+        alarm = Alarm(self, resp["state"]["status"], assumed)
+        self._last_status_update = update_time
+        self._latest_state = alarm
+        for handler in list(self._state_handlers):
+          await handler(alarm)
     event_ts_str = data.get("LastEventUpdated")
     if event_ts_str and self._event_handlers:
       event_time = datetime.fromisoformat(event_ts_str)
@@ -280,7 +278,7 @@ class RiscoCloud:
       "offset": 0,
     }
     response, assumed_control_panel_state = await self._site_post(EVENTS_URL, body)
-    if not response:
+    if response is None:
       return []
     return [Event(e) for e in response["controlPanelEventsList"]]
 

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -184,10 +184,11 @@ class RiscoCloud:
     for handler in list(self._state_handlers):
       await handler(alarm)
     event_ts_str = data.get("LastEventUpdated")
-    if event_ts_str:
+    if event_ts_str and self._event_handlers:
       event_time = datetime.fromisoformat(event_ts_str)
       if self._last_event_update is None or event_time > self._last_event_update:
-        events = await self.get_events(self._last_event_update)
+        newer_than = self._last_event_update.isoformat() if self._last_event_update else None
+        events = await self.get_events(newer_than)
         self._last_event_update = event_time
         for handler in list(self._event_handlers):
           await handler(events)

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -103,8 +103,7 @@ class RiscoCloud:
         if isinstance(e, RetryableOperationError):
           from_control_panel = False
         elif isinstance(e, UnauthorizedError):
-          await self.close()
-          await self.login()
+          await self._relogin()
 
   async def _login_user_pass(self):
     headers = {"Content-Type": "application/json", "User-Agent": "pyrisco/1.0"}
@@ -143,6 +142,13 @@ class RiscoCloud:
         self._created_session = True
       else:
         self._session = session
+
+  async def _relogin(self):
+    """Refresh credentials in-place without closing the session or the SSE task."""
+    self._session_id = None
+    await self._login_user_pass()
+    await self._login_site()
+    await self._login_session()
 
   async def _send_control_command(self, body):
     resp, assumed_control_panel_state = await self._site_post(CONTROL_URL, body)
@@ -222,12 +228,11 @@ class RiscoCloud:
     """Close the connection."""
     self._session_id = None
     if self._subscription_task:
-      if asyncio.current_task() != self._subscription_task:
-        self._subscription_task.cancel()
-        try:
-          await self._subscription_task
-        except (asyncio.CancelledError, Exception):
-          pass
+      self._subscription_task.cancel()
+      try:
+        await self._subscription_task
+      except (asyncio.CancelledError, Exception):
+        pass
       self._subscription_task = None
     if self._created_session and self._session is not None:
       await self._session.close()

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -175,6 +175,7 @@ class RiscoCloud:
               event_type = None
               data_line = None
         attempt = 0  # successful connection — reset backoff for next drop
+        await asyncio.sleep(RECONNECT_INITIAL_DELAY)  # small delay before reconnecting on clean EOF
       except asyncio.CancelledError:
         raise
       except Exception as e:
@@ -215,11 +216,12 @@ class RiscoCloud:
     """Close the connection."""
     self._session_id = None
     if self._subscription_task:
-      self._subscription_task.cancel()
-      try:
-        await self._subscription_task
-      except (asyncio.CancelledError, Exception):
-        pass
+      if asyncio.current_task() != self._subscription_task:
+        self._subscription_task.cancel()
+        try:
+          await self._subscription_task
+        except (asyncio.CancelledError, Exception):
+          pass
       self._subscription_task = None
     if self._created_session and self._session is not None:
       await self._session.close()

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -150,6 +150,13 @@ class RiscoCloud:
       }
       params = {"sessionToken": self._session_id}
       async with self._session.get(url, headers=headers, params=params) as resp:
+        # SSE connection is now open — fetch initial state before consuming
+        # messages so no state changes in between can be missed.
+        initial_resp, assumed = await self._site_post(STATE_URL, {})
+        alarm = Alarm(self, initial_resp["state"]["status"], assumed)
+        self._latest_state = alarm
+        for handler in list(self._state_handlers):
+          await handler(alarm)
         event_type = None
         data_line = None
         async for line_bytes in resp.content:

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -160,6 +160,7 @@ class RiscoCloud:
         }
         params = {"sessionToken": self._session_id}
         async with self._session.get(url, headers=headers, params=params) as resp:
+          resp.raise_for_status()
           # SSE connection is now open — fetch initial state before consuming
           # messages so no state changes in between can be missed.
           initial_resp, assumed = await self._site_post(STATE_URL, {})
@@ -221,8 +222,8 @@ class RiscoCloud:
     """Close the connection."""
     self._session_id = None
     if self._subscription_task:
-      self._subscription_task.cancel()
       if asyncio.current_task() != self._subscription_task:
+        self._subscription_task.cancel()
         try:
           await self._subscription_task
         except (asyncio.CancelledError, Exception):

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -43,7 +43,9 @@ class RiscoCloud:
     self._created_session = False
     self._state_handlers = []
     self._error_handlers = []
+    self._event_handlers = []
     self._last_status_update = None
+    self._last_event_update = None
     self._latest_state = None
     self._subscription_task = None
 
@@ -167,9 +169,9 @@ class RiscoCloud:
         await handler(e)
 
   async def _handle_runtime_update(self, data):
-    if data.get("isOffline"):
+    if data.get("IsOffline"):
       return
-    ts_str = data.get("lastStatusUpdate")
+    ts_str = data.get("LastStatusUpdate")
     if not ts_str:
       return
     update_time = datetime.fromisoformat(ts_str)
@@ -181,6 +183,14 @@ class RiscoCloud:
     self._latest_state = alarm
     for handler in list(self._state_handlers):
       await handler(alarm)
+    event_ts_str = data.get("LastEventUpdated")
+    if event_ts_str:
+      event_time = datetime.fromisoformat(event_ts_str)
+      if self._last_event_update is None or event_time > self._last_event_update:
+        events = await self.get_events(self._last_event_update)
+        self._last_event_update = event_time
+        for handler in list(self._event_handlers):
+          await handler(events)
 
   async def close(self):
     """Close the connection."""
@@ -214,6 +224,10 @@ class RiscoCloud:
   def add_error_handler(self, handler):
     """Register an async callback for SSE errors. Returns a remover callable."""
     return RiscoCloud._add_handler(self._error_handlers, handler)
+
+  def add_event_handler(self, handler):
+    """Register an async callback for event log updates via SSE. Returns a remover callable."""
+    return RiscoCloud._add_handler(self._event_handlers, handler)
 
   async def subscribe_states(self):
     """Start listening for push state updates via SSE."""

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -216,8 +216,8 @@ class RiscoCloud:
     """Close the connection."""
     self._session_id = None
     if self._subscription_task:
+      self._subscription_task.cancel()
       if asyncio.current_task() != self._subscription_task:
-        self._subscription_task.cancel()
         try:
           await self._subscription_task
         except (asyncio.CancelledError, Exception):

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -279,6 +279,8 @@ class RiscoCloud:
       "offset": 0,
     }
     response, assumed_control_panel_state = await self._site_post(EVENTS_URL, body)
+    if not response:
+      return []
     return [Event(e) for e in response["controlPanelEventsList"]]
 
   async def bypass_zone(self, zone, bypass):

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -191,10 +191,10 @@ class RiscoCloud:
     event_ts_str = data.get("LastEventUpdated")
     if event_ts_str and self._event_handlers:
       event_time = datetime.fromisoformat(event_ts_str)
-      if self._last_event_update is None or event_time > self._last_event_update:
-        newer_than = self._last_event_update.isoformat() if self._last_event_update else None
-        events = await self.get_events(newer_than)
-        self._last_event_update = event_time
+      last_event_time = datetime.fromisoformat(self._last_event_update) if self._last_event_update else None
+      if last_event_time is None or event_time > last_event_time:
+        events = await self.get_events(self._last_event_update)
+        self._last_event_update = event_ts_str
         for handler in list(self._event_handlers):
           await handler(events)
 

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -168,6 +168,7 @@ class RiscoCloud:
           self._latest_state = alarm
           for handler in list(self._state_handlers):
             await handler(alarm)
+          attempt = 0  # usable connection established — reset backoff counter
           event_type = None
           data_line = None
           async for line_bytes in resp.content:
@@ -180,8 +181,7 @@ class RiscoCloud:
               await self._handle_runtime_update(json.loads(data_line))
               event_type = None
               data_line = None
-        attempt = 0  # clean stream end — reset backoff for next drop
-        await asyncio.sleep(RECONNECT_INITIAL_DELAY)  # small delay before reconnecting
+        await asyncio.sleep(RECONNECT_INITIAL_DELAY)  # small delay before reconnecting on clean EOF
       except asyncio.CancelledError:
         raise
       except Exception as e:
@@ -223,10 +223,11 @@ class RiscoCloud:
     self._session_id = None
     if self._subscription_task:
       self._subscription_task.cancel()
-      try:
-        await self._subscription_task
-      except (asyncio.CancelledError, Exception):
-        pass
+      if asyncio.current_task() != self._subscription_task:
+        try:
+          await self._subscription_task
+        except (asyncio.CancelledError, Exception):
+          pass
       self._subscription_task = None
     if self._created_session and self._session is not None:
       await self._session.close()

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -65,13 +65,12 @@ class RiscoCloud:
     return _remove
 
   @staticmethod
-  async def _call_handlers(handlers, *params):
-    """Call handlers, swallowing exceptions so a buggy callback doesn't break the SSE loop."""
-    for handler in list(handlers):
-      try:
-        await handler(*params)
-      except Exception:
-        pass
+  def _call_handlers(handlers, *params):
+    """Dispatch handlers asynchronously so a slow/buggy callback doesn't block the SSE loop."""
+    if handlers:
+      async def _gather():
+        await asyncio.gather(*[h(*params) for h in list(handlers)], return_exceptions=True)
+      asyncio.create_task(_gather())
 
   async def _authenticated_post(self, url, body):
     headers = {
@@ -175,7 +174,7 @@ class RiscoCloud:
           initial_resp, assumed = await self._site_post(STATE_URL, {})
           alarm = Alarm(self, initial_resp["state"]["status"], assumed)
           self._latest_state = alarm
-          await RiscoCloud._call_handlers(self._state_handlers, alarm)
+          RiscoCloud._call_handlers(self._state_handlers, alarm)
           attempt = 0  # usable connection established — reset backoff counter
           event_type = None
           data_line = None
@@ -195,11 +194,9 @@ class RiscoCloud:
       except Exception as e:
         attempt += 1
         if attempt >= RECONNECT_MAX_ATTEMPTS:
-          for handler in list(self._error_handlers):
-            await handler(MaxRetriesError(e))
+          RiscoCloud._call_handlers(self._error_handlers, MaxRetriesError(e))
           return
-        for handler in list(self._error_handlers):
-          await handler(e)
+        RiscoCloud._call_handlers(self._error_handlers, e)
         delay = min(RECONNECT_INITIAL_DELAY * (2 ** (attempt - 1)), RECONNECT_MAX_DELAY)
         await asyncio.sleep(delay)
 
@@ -214,7 +211,7 @@ class RiscoCloud:
         alarm = Alarm(self, resp["state"]["status"], assumed)
         self._last_status_update = update_time
         self._latest_state = alarm
-        await RiscoCloud._call_handlers(self._state_handlers, alarm)
+        RiscoCloud._call_handlers(self._state_handlers, alarm)
     event_ts_str = data.get("LastEventUpdated")
     if event_ts_str and self._event_handlers:
       event_time = _parse_timestamp(event_ts_str)
@@ -222,7 +219,7 @@ class RiscoCloud:
       if last_event_time is None or event_time > last_event_time:
         events = await self.get_events(self._last_event_update)
         self._last_event_update = event_ts_str
-        await RiscoCloud._call_handlers(self._event_handlers, events)
+        RiscoCloud._call_handlers(self._event_handlers, events)
 
   async def close(self):
     """Close the connection."""

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -10,6 +10,11 @@ from .event import Event
 from pyrisco.common import UnauthorizedError, CannotConnectError, OperationError, RetryableOperationError, MaxRetriesError, GROUP_ID_TO_NAME
 
 
+def _parse_timestamp(ts_str):
+  """Parse an ISO 8601 timestamp, accepting both 'Z' and '+00:00' UTC suffixes."""
+  return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+
+
 LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
 SITE_URL = "https://www.riscocloud.com/webapi/api/wuws/site/GetAll"
 PIN_URL = "https://www.riscocloud.com/webapi/api/wuws/site/%s/Login"
@@ -194,7 +199,7 @@ class RiscoCloud:
       return
     ts_str = data.get("LastStatusUpdate")
     if ts_str:
-      update_time = datetime.fromisoformat(ts_str)
+      update_time = _parse_timestamp(ts_str)
       if self._last_status_update is None or update_time > self._last_status_update:
         resp, assumed = await self._site_post(STATE_URL, {})
         alarm = Alarm(self, resp["state"]["status"], assumed)
@@ -204,8 +209,8 @@ class RiscoCloud:
           await handler(alarm)
     event_ts_str = data.get("LastEventUpdated")
     if event_ts_str and self._event_handlers:
-      event_time = datetime.fromisoformat(event_ts_str)
-      last_event_time = datetime.fromisoformat(self._last_event_update) if self._last_event_update else None
+      event_time = _parse_timestamp(event_ts_str)
+      last_event_time = _parse_timestamp(self._last_event_update) if self._last_event_update else None
       if last_event_time is None or event_time > last_event_time:
         events = await self.get_events(self._last_event_update)
         self._last_event_update = event_ts_str

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -64,6 +64,15 @@ class RiscoCloud:
       handlers.remove(handler)
     return _remove
 
+  @staticmethod
+  async def _call_handlers(handlers, *params):
+    """Call handlers, swallowing exceptions so a buggy callback doesn't break the SSE loop."""
+    for handler in list(handlers):
+      try:
+        await handler(*params)
+      except Exception:
+        pass
+
   async def _authenticated_post(self, url, body):
     headers = {
       "Content-Type": "application/json",
@@ -166,8 +175,7 @@ class RiscoCloud:
           initial_resp, assumed = await self._site_post(STATE_URL, {})
           alarm = Alarm(self, initial_resp["state"]["status"], assumed)
           self._latest_state = alarm
-          for handler in list(self._state_handlers):
-            await handler(alarm)
+          await RiscoCloud._call_handlers(self._state_handlers, alarm)
           attempt = 0  # usable connection established — reset backoff counter
           event_type = None
           data_line = None
@@ -206,8 +214,7 @@ class RiscoCloud:
         alarm = Alarm(self, resp["state"]["status"], assumed)
         self._last_status_update = update_time
         self._latest_state = alarm
-        for handler in list(self._state_handlers):
-          await handler(alarm)
+        await RiscoCloud._call_handlers(self._state_handlers, alarm)
     event_ts_str = data.get("LastEventUpdated")
     if event_ts_str and self._event_handlers:
       event_time = _parse_timestamp(event_ts_str)
@@ -215,8 +222,7 @@ class RiscoCloud:
       if last_event_time is None or event_time > last_event_time:
         events = await self.get_events(self._last_event_update)
         self._last_event_update = event_ts_str
-        for handler in list(self._event_handlers):
-          await handler(events)
+        await RiscoCloud._call_handlers(self._event_handlers, events)
 
   async def close(self):
     """Close the connection."""

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -23,6 +23,7 @@ SSE_URL = "https://www.riscocloud.com/webapi/api/wuws/site/%s/ControlPanel/sse/c
 
 NUM_RETRIES = 3
 RETRYABLE_RESULT_CODE = 72
+RECONNECT_DELAY = 30
 
 
 class RiscoCloud:
@@ -141,39 +142,41 @@ class RiscoCloud:
     return Alarm(self, resp, assumed_control_panel_state)
 
   async def _sse_loop(self):
-    try:
-      url = SSE_URL % self._site_id
-      headers = {
-        "authorization": f"Bearer {self._access_token}",
-        "User-Agent": "pyrisco/1.0",
-        "sessionToken": self._session_id,
-      }
-      params = {"sessionToken": self._session_id}
-      async with self._session.get(url, headers=headers, params=params) as resp:
-        # SSE connection is now open — fetch initial state before consuming
-        # messages so no state changes in between can be missed.
-        initial_resp, assumed = await self._site_post(STATE_URL, {})
-        alarm = Alarm(self, initial_resp["state"]["status"], assumed)
-        self._latest_state = alarm
-        for handler in list(self._state_handlers):
-          await handler(alarm)
-        event_type = None
-        data_line = None
-        async for line_bytes in resp.content:
-          line = line_bytes.decode("utf-8").rstrip("\r\n")
-          if line.startswith("event:"):
-            event_type = line[6:].strip()
-          elif line.startswith("data:"):
-            data_line = line[5:].strip()
-          elif line == "" and event_type == "runtimeUpdate" and data_line:
-            await self._handle_runtime_update(json.loads(data_line))
-            event_type = None
-            data_line = None
-    except asyncio.CancelledError:
-      raise
-    except Exception as e:
-      for handler in list(self._error_handlers):
-        await handler(e)
+    while True:
+      try:
+        url = SSE_URL % self._site_id
+        headers = {
+          "authorization": f"Bearer {self._access_token}",
+          "User-Agent": "pyrisco/1.0",
+          "sessionToken": self._session_id,
+        }
+        params = {"sessionToken": self._session_id}
+        async with self._session.get(url, headers=headers, params=params) as resp:
+          # SSE connection is now open — fetch initial state before consuming
+          # messages so no state changes in between can be missed.
+          initial_resp, assumed = await self._site_post(STATE_URL, {})
+          alarm = Alarm(self, initial_resp["state"]["status"], assumed)
+          self._latest_state = alarm
+          for handler in list(self._state_handlers):
+            await handler(alarm)
+          event_type = None
+          data_line = None
+          async for line_bytes in resp.content:
+            line = line_bytes.decode("utf-8").rstrip("\r\n")
+            if line.startswith("event:"):
+              event_type = line[6:].strip()
+            elif line.startswith("data:"):
+              data_line = line[5:].strip()
+            elif line == "" and event_type == "runtimeUpdate" and data_line:
+              await self._handle_runtime_update(json.loads(data_line))
+              event_type = None
+              data_line = None
+      except asyncio.CancelledError:
+        raise
+      except Exception as e:
+        for handler in list(self._error_handlers):
+          await handler(e)
+        await asyncio.sleep(RECONNECT_DELAY)
 
   async def _handle_runtime_update(self, data):
     if data.get("IsOffline"):

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from .alarm import Alarm
 from .event import Event
-from pyrisco.common import UnauthorizedError, CannotConnectError, OperationError, RetryableOperationError, GROUP_ID_TO_NAME
+from pyrisco.common import UnauthorizedError, CannotConnectError, OperationError, RetryableOperationError, MaxRetriesError, GROUP_ID_TO_NAME
 
 
 LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
@@ -23,7 +23,9 @@ SSE_URL = "https://www.riscocloud.com/webapi/api/wuws/site/%s/ControlPanel/sse/c
 
 NUM_RETRIES = 3
 RETRYABLE_RESULT_CODE = 72
-RECONNECT_DELAY = 30
+RECONNECT_INITIAL_DELAY = 1
+RECONNECT_MAX_DELAY = 60
+RECONNECT_MAX_ATTEMPTS = 5
 
 
 class RiscoCloud:
@@ -142,6 +144,7 @@ class RiscoCloud:
     return Alarm(self, resp, assumed_control_panel_state)
 
   async def _sse_loop(self):
+    attempt = 0
     while True:
       try:
         url = SSE_URL % self._site_id
@@ -171,12 +174,19 @@ class RiscoCloud:
               await self._handle_runtime_update(json.loads(data_line))
               event_type = None
               data_line = None
+        attempt = 0  # successful connection — reset backoff for next drop
       except asyncio.CancelledError:
         raise
       except Exception as e:
+        attempt += 1
+        if attempt >= RECONNECT_MAX_ATTEMPTS:
+          for handler in list(self._error_handlers):
+            await handler(MaxRetriesError(e))
+          return
         for handler in list(self._error_handlers):
           await handler(e)
-        await asyncio.sleep(RECONNECT_DELAY)
+        delay = min(RECONNECT_INITIAL_DELAY * (2 ** (attempt - 1)), RECONNECT_MAX_DELAY)
+        await asyncio.sleep(delay)
 
   async def _handle_runtime_update(self, data):
     if data.get("IsOffline"):

--- a/pyrisco/cloud/risco_cloud.py
+++ b/pyrisco/cloud/risco_cloud.py
@@ -103,7 +103,8 @@ class RiscoCloud:
         if isinstance(e, RetryableOperationError):
           from_control_panel = False
         elif isinstance(e, UnauthorizedError):
-          await self._relogin()
+          await self.close()
+          await self.login()
 
   async def _login_user_pass(self):
     headers = {"Content-Type": "application/json", "User-Agent": "pyrisco/1.0"}
@@ -143,13 +144,6 @@ class RiscoCloud:
       else:
         self._session = session
 
-  async def _relogin(self):
-    """Refresh credentials in-place without closing the session or the SSE task."""
-    self._session_id = None
-    await self._login_user_pass()
-    await self._login_site()
-    await self._login_session()
-
   async def _send_control_command(self, body):
     resp, assumed_control_panel_state = await self._site_post(CONTROL_URL, body)
     return Alarm(self, resp, assumed_control_panel_state)
@@ -186,8 +180,8 @@ class RiscoCloud:
               await self._handle_runtime_update(json.loads(data_line))
               event_type = None
               data_line = None
-        attempt = 0  # successful connection — reset backoff for next drop
-        await asyncio.sleep(RECONNECT_INITIAL_DELAY)  # small delay before reconnecting on clean EOF
+        attempt = 0  # clean stream end — reset backoff for next drop
+        await asyncio.sleep(RECONNECT_INITIAL_DELAY)  # small delay before reconnecting
       except asyncio.CancelledError:
         raise
       except Exception as e:

--- a/pyrisco/common.py
+++ b/pyrisco/common.py
@@ -147,3 +147,11 @@ class OperationError(Exception):
 
 class RetryableOperationError(OperationError):
   """Exception to indicate an error in operation that can be retried and might succeed."""
+
+
+class MaxRetriesError(Exception):
+  """Raised when the SSE connection fails and all reconnect attempts are exhausted."""
+
+  def __init__(self, last_error):
+    self.last_error = last_error
+    super().__init__(f"SSE reconnect failed after maximum attempts: {last_error}")

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -22,13 +22,20 @@ def _make_cancel_cm():
   return cm
 
 
+async def _drain_handler_tasks():
+  """Wait for all handler tasks spawned by _call_handlers to finish."""
+  pending = {t for t in asyncio.all_tasks() if t != asyncio.current_task()}
+  if pending:
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
 async def _run_sse_task(risco_cloud):
-  """Await the SSE subscription task, then yield so handler tasks can run."""
+  """Await the SSE subscription task, then drain any handler tasks."""
   try:
     await risco_cloud._subscription_task
   except asyncio.CancelledError:
     pass
-  await asyncio.sleep(0)  # let any pending tasks settle
+  await _drain_handler_tasks()
 
 
 def _make_sse_stream(*events):
@@ -452,6 +459,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
       await risco_cloud._subscription_task
     except asyncio.CancelledError:
       pass
+    await _drain_handler_tasks()
 
     self.assertEqual(len(received_errors), 1)
     self.assertIs(received_errors[0], error)
@@ -593,6 +601,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     await risco_cloud.subscribe_states()
     await risco_cloud._subscription_task  # completes normally after giving up
+    await _drain_handler_tasks()
 
     # Error handler called once per attempt: first N-1 with the raw error, last with MaxRetriesError
     self.assertEqual(len(received_errors), RECONNECT_MAX_ATTEMPTS)

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -2,10 +2,31 @@ import asyncio
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, MagicMock
-from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError
+from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError, RECONNECT_DELAY
 from pyrisco.cloud.alarm import Alarm
 
 LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
+
+
+def _make_cancel_cm():
+  """Return a mock async context manager that raises CancelledError on enter.
+
+  Used to stop the SSE reconnect loop cleanly in tests: set the second
+  session.get() side_effect entry to _make_cancel_cm() so the loop exits
+  as soon as it tries to reconnect after the test stream ends.
+  """
+  cm = MagicMock()
+  cm.__aenter__ = AsyncMock(side_effect=asyncio.CancelledError)
+  cm.__aexit__ = AsyncMock(return_value=None)
+  return cm
+
+
+async def _run_sse_task(risco_cloud):
+  """Await the SSE subscription task, absorbing the CancelledError from reconnect."""
+  try:
+    await risco_cloud._subscription_task
+  except asyncio.CancelledError:
+    pass
 
 
 def _make_sse_stream(*events):
@@ -218,7 +239,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received = []
     async def on_state(alarm):
@@ -232,7 +253,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_state_handler(on_state)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received), 1)
     self.assertIsInstance(received[0], Alarm)
@@ -253,7 +274,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received = []
     async def on_state(alarm):
@@ -267,7 +288,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_state_handler(on_state)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received), 2)  # initial fetch + SSE-triggered fetch
     self.assertIsInstance(received[0], Alarm)
@@ -288,7 +309,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     risco_cloud = RiscoCloud("username", "password", "pin")
     risco_cloud._access_token = "mock_access_token"
@@ -297,7 +318,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud._session = mock_session
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     # initial fetch + first SSE message; second SSE message has same timestamp so skipped
     self.assertEqual(mock_site_post.call_count, 2)
@@ -331,7 +352,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     risco_cloud = RiscoCloud("username", "password", "pin")
     risco_cloud._access_token = "mock_access_token"
@@ -340,7 +361,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud._session = mock_session
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     # Only the initial fetch; the SSE message is skipped because IsOffline=True
     self.assertEqual(mock_site_post.call_count, 1)
@@ -364,7 +385,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received_events = []
     async def on_event(events):
@@ -378,16 +399,19 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_event_handler(on_event)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received_events), 1)
     self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + event fetch
 
+  @patch('pyrisco.cloud.risco_cloud.asyncio.sleep', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-  async def test_subscribe_states_calls_error_handler(self, MockClientSession, mock_site_post):
+  async def test_subscribe_states_calls_error_handler(self, MockClientSession, mock_site_post, mock_sleep):
     state_payload = {"partitions": [], "zones": []}
     mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+    # Make sleep raise CancelledError so the loop stops cleanly after the first retry delay
+    mock_sleep.side_effect = asyncio.CancelledError
 
     mock_session = MockClientSession.return_value
     error = RuntimeError("stream broken")
@@ -415,10 +439,14 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_error_handler(on_error)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    try:
+      await risco_cloud._subscription_task
+    except asyncio.CancelledError:
+      pass
 
     self.assertEqual(len(received_errors), 1)
     self.assertIs(received_errors[0], error)
+    mock_sleep.assert_awaited_once_with(RECONNECT_DELAY)
 
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
@@ -442,7 +470,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received_events = []
     async def on_event(events):
@@ -456,7 +484,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_event_handler(on_event)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received_events), 1)
     self.assertEqual(received_events[0], [])
@@ -483,7 +511,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received_events = []
     async def on_event(events):
@@ -497,7 +525,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_event_handler(on_event)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received_events), 1)
     self.assertIsInstance(received_events[0], list)
@@ -516,7 +544,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_get_cm.__aexit__ = AsyncMock(return_value=None)
-    mock_session.get.return_value = mock_get_cm
+    mock_session.get.side_effect = [mock_get_cm, _make_cancel_cm()]
 
     received_events = []
     async def on_event(events):
@@ -530,7 +558,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     risco_cloud.add_event_handler(on_event)
 
     await risco_cloud.subscribe_states()
-    await risco_cloud._subscription_task
+    await _run_sse_task(risco_cloud)
 
     self.assertEqual(len(received_events), 0)
     self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + state fetch from SSE, no event fetch

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -23,11 +23,12 @@ def _make_cancel_cm():
 
 
 async def _run_sse_task(risco_cloud):
-  """Await the SSE subscription task, absorbing the CancelledError from reconnect."""
+  """Await the SSE subscription task, then yield so handler tasks can run."""
   try:
     await risco_cloud._subscription_task
   except asyncio.CancelledError:
     pass
+  await asyncio.sleep(0)  # let any pending tasks settle
 
 
 def _make_sse_stream(*events):

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -338,7 +338,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud._subscription_task
 
     self.assertEqual(len(received_events), 1)
-    mock_site_post.call_count == 1  # only event fetch, no state fetch
+    self.assertEqual(mock_site_post.call_count, 1)  # only event fetch, no state fetch
 
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_calls_error_handler(self, MockClientSession):

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -342,6 +342,45 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_calls_event_handler_with_null_response(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.side_effect = [
+      ({"state": {"status": state_payload}}, False),
+      (None, False),
+    ]
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {
+        "LastStatusUpdate": "2024-01-01T12:00:00Z",
+        "LastEventUpdated": "2024-01-01T12:00:00Z",
+      }),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received_events = []
+    async def on_event(events):
+      received_events.append(events)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_event_handler(on_event)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received_events), 1)
+    self.assertEqual(received_events[0], [])
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_calls_event_handler(self, MockClientSession, mock_site_post):
     state_payload = {"partitions": [], "zones": []}
     event_payload = {"controlPanelEventsList": []}

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -207,8 +207,42 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_notifies_handler_immediately(self, MockClientSession, mock_site_post):
+    """Handler should be called right after SSE connects, before any SSE messages."""
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream()  # no SSE messages
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received = []
+    async def on_state(alarm):
+      received.append(alarm)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_state_handler(on_state)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received), 1)
+    self.assertIsInstance(received[0], Alarm)
+    self.assertEqual(mock_site_post.call_count, 1)
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_calls_handler(self, MockClientSession, mock_site_post):
     state_payload = {"partitions": [], "zones": []}
+    # Two calls: initial state fetch + state fetch triggered by SSE message
     mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
 
     mock_session = MockClientSession.return_value
@@ -235,9 +269,9 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud.subscribe_states()
     await risco_cloud._subscription_task
 
-    self.assertEqual(len(received), 1)
+    self.assertEqual(len(received), 2)  # initial fetch + SSE-triggered fetch
     self.assertIsInstance(received[0], Alarm)
-    self.assertEqual(mock_site_post.call_count, 1)
+    self.assertEqual(mock_site_post.call_count, 2)
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
@@ -265,7 +299,8 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud.subscribe_states()
     await risco_cloud._subscription_task
 
-    self.assertEqual(mock_site_post.call_count, 1)
+    # initial fetch + first SSE message; second SSE message has same timestamp so skipped
+    self.assertEqual(mock_site_post.call_count, 2)
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   async def test_get_state_returns_cached(self, mock_site_post):
@@ -285,6 +320,9 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_skips_fetch_when_offline(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
     mock_session = MockClientSession.return_value
     mock_resp = MagicMock()
     mock_resp.content = _make_sse_stream(
@@ -304,14 +342,19 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud.subscribe_states()
     await risco_cloud._subscription_task
 
-    mock_site_post.assert_not_called()
+    # Only the initial fetch; the SSE message is skipped because IsOffline=True
+    self.assertEqual(mock_site_post.call_count, 1)
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_event_handler_fires_without_status_update(self, MockClientSession, mock_site_post):
     """LastEventUpdated should trigger the event handler even when LastStatusUpdate is absent."""
+    state_payload = {"partitions": [], "zones": []}
     event_payload = {"controlPanelEventsList": []}
-    mock_site_post.return_value = (event_payload, False)
+    mock_site_post.side_effect = [
+      ({"state": {"status": state_payload}}, False),  # initial state fetch
+      (event_payload, False),                          # event fetch from SSE message
+    ]
 
     mock_session = MockClientSession.return_value
     mock_resp = MagicMock()
@@ -338,10 +381,14 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud._subscription_task
 
     self.assertEqual(len(received_events), 1)
-    self.assertEqual(mock_site_post.call_count, 1)  # only event fetch, no state fetch
+    self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + event fetch
 
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-  async def test_subscribe_states_calls_error_handler(self, MockClientSession):
+  async def test_subscribe_states_calls_error_handler(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
     mock_session = MockClientSession.return_value
     error = RuntimeError("stream broken")
 
@@ -379,8 +426,9 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
   async def test_subscribe_states_calls_event_handler_with_null_response(self, MockClientSession, mock_site_post):
     state_payload = {"partitions": [], "zones": []}
     mock_site_post.side_effect = [
-      ({"state": {"status": state_payload}}, False),
-      (None, False),
+      ({"state": {"status": state_payload}}, False),  # initial state fetch
+      ({"state": {"status": state_payload}}, False),  # state fetch from SSE message
+      (None, False),                                   # event fetch returns null
     ]
 
     mock_session = MockClientSession.return_value
@@ -419,8 +467,9 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     state_payload = {"partitions": [], "zones": []}
     event_payload = {"controlPanelEventsList": []}
     mock_site_post.side_effect = [
-      ({"state": {"status": state_payload}}, False),
-      (event_payload, False),
+      ({"state": {"status": state_payload}}, False),  # initial state fetch
+      ({"state": {"status": state_payload}}, False),  # state fetch from SSE message
+      (event_payload, False),                          # event fetch
     ]
 
     mock_session = MockClientSession.return_value
@@ -484,7 +533,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     await risco_cloud._subscription_task
 
     self.assertEqual(len(received_events), 0)
-    self.assertEqual(mock_site_post.call_count, 1)  # only the state fetch, no event fetch
+    self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + state fetch from SSE, no event fetch
 
 
 if __name__ == '__main__':

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -214,7 +214,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_session = MockClientSession.return_value
     mock_resp = MagicMock()
     mock_resp.content = _make_sse_stream(
-      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
+      ("runtimeUpdate", {"LastStatusUpdate": "2024-01-01T12:00:00Z"}),
     )
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
@@ -248,8 +248,8 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_session = MockClientSession.return_value
     mock_resp = MagicMock()
     mock_resp.content = _make_sse_stream(
-      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
-      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z"}),
+      ("runtimeUpdate", {"LastStatusUpdate": "2024-01-01T12:00:00Z"}),
+      ("runtimeUpdate", {"LastStatusUpdate": "2024-01-01T12:00:00Z"}),
     )
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
@@ -288,7 +288,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     mock_session = MockClientSession.return_value
     mock_resp = MagicMock()
     mock_resp.content = _make_sse_stream(
-      ("runtimeUpdate", {"lastStatusUpdate": "2024-01-01T12:00:00Z", "isOffline": True}),
+      ("runtimeUpdate", {"LastStatusUpdate": "2024-01-01T12:00:00Z", "IsOffline": True}),
     )
     mock_get_cm = MagicMock()
     mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
@@ -338,6 +338,80 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     self.assertEqual(len(received_errors), 1)
     self.assertIs(received_errors[0], error)
+
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_calls_event_handler(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    event_payload = {"controlPanelEventsList": []}
+    mock_site_post.side_effect = [
+      ({"state": {"status": state_payload}}, False),
+      (event_payload, False),
+    ]
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {
+        "LastStatusUpdate": "2024-01-01T12:00:00Z",
+        "LastEventUpdated": "2024-01-01T12:00:00Z",
+      }),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received_events = []
+    async def on_event(events):
+      received_events.append(events)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_event_handler(on_event)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received_events), 1)
+    self.assertIsInstance(received_events[0], list)
+
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_no_event_handler_when_no_last_event_updated(self, MockClientSession, mock_site_post):
+    state_payload = {"partitions": [], "zones": []}
+    mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {"LastStatusUpdate": "2024-01-01T12:00:00Z"}),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received_events = []
+    async def on_event(events):
+      received_events.append(events)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_event_handler(on_event)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received_events), 0)
+    self.assertEqual(mock_site_post.call_count, 1)  # only the state fetch, no event fetch
 
 
 if __name__ == '__main__':

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -306,6 +306,40 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     mock_site_post.assert_not_called()
 
+  @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_event_handler_fires_without_status_update(self, MockClientSession, mock_site_post):
+    """LastEventUpdated should trigger the event handler even when LastStatusUpdate is absent."""
+    event_payload = {"controlPanelEventsList": []}
+    mock_site_post.return_value = (event_payload, False)
+
+    mock_session = MockClientSession.return_value
+    mock_resp = MagicMock()
+    mock_resp.content = _make_sse_stream(
+      ("runtimeUpdate", {"LastEventUpdated": "2024-01-01T12:00:00Z"}),
+    )
+    mock_get_cm = MagicMock()
+    mock_get_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_get_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get.return_value = mock_get_cm
+
+    received_events = []
+    async def on_event(events):
+      received_events.append(events)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_event_handler(on_event)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task
+
+    self.assertEqual(len(received_events), 1)
+    mock_site_post.call_count == 1  # only event fetch, no state fetch
+
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_subscribe_states_calls_error_handler(self, MockClientSession):
     mock_session = MockClientSession.return_value

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -2,7 +2,8 @@ import asyncio
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import patch, AsyncMock, MagicMock
-from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError, RECONNECT_DELAY
+from pyrisco.cloud.risco_cloud import RiscoCloud, UnauthorizedError, OperationError, RetryableOperationError, RECONNECT_INITIAL_DELAY, RECONNECT_MAX_ATTEMPTS
+from pyrisco.common import MaxRetriesError
 from pyrisco.cloud.alarm import Alarm
 
 LOGIN_URL = "https://www.riscocloud.com/webapi/api/auth/login"
@@ -446,7 +447,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     self.assertEqual(len(received_errors), 1)
     self.assertIs(received_errors[0], error)
-    mock_sleep.assert_awaited_once_with(RECONNECT_DELAY)
+    mock_sleep.assert_awaited_once_with(RECONNECT_INITIAL_DELAY)  # first attempt: 1s
 
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
@@ -562,6 +563,41 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     self.assertEqual(len(received_events), 0)
     self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + state fetch from SSE, no event fetch
+
+
+  @patch('pyrisco.cloud.risco_cloud.asyncio.sleep', new_callable=AsyncMock)
+  @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
+  async def test_subscribe_states_max_retries_exceeded(self, MockClientSession, mock_sleep):
+    """After RECONNECT_MAX_ATTEMPTS failures the loop gives up and notifies via MaxRetriesError."""
+    mock_session = MockClientSession.return_value
+    error = RuntimeError("connection failed")
+    mock_session.get.side_effect = error
+
+    received_errors = []
+    async def on_error(err):
+      received_errors.append(err)
+
+    risco_cloud = RiscoCloud("username", "password", "pin")
+    risco_cloud._access_token = "mock_access_token"
+    risco_cloud._site_id = "mock_site_id"
+    risco_cloud._session_id = "mock_session_id"
+    risco_cloud._session = mock_session
+    risco_cloud.add_error_handler(on_error)
+
+    await risco_cloud.subscribe_states()
+    await risco_cloud._subscription_task  # completes normally after giving up
+
+    # Error handler called once per attempt: first N-1 with the raw error, last with MaxRetriesError
+    self.assertEqual(len(received_errors), RECONNECT_MAX_ATTEMPTS)
+    for i in range(RECONNECT_MAX_ATTEMPTS - 1):
+      self.assertIs(received_errors[i], error)
+    self.assertIsInstance(received_errors[-1], MaxRetriesError)
+    self.assertIs(received_errors[-1].last_error, error)
+
+    # Sleep called with exponential backoff (no sleep on final attempt)
+    self.assertEqual(mock_sleep.await_count, RECONNECT_MAX_ATTEMPTS - 1)
+    for i, expected_delay in enumerate([1, 2, 4, 8]):
+      self.assertEqual(mock_sleep.await_args_list[i].args[0], expected_delay)
 
 
 if __name__ == '__main__':

--- a/tests/test_risco_cloud.py
+++ b/tests/test_risco_cloud.py
@@ -51,6 +51,14 @@ def _make_sse_stream(*events):
 
 class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
+  def setUp(self):
+    # Mock asyncio.sleep globally for all tests so SSE reconnect delays don't slow the suite.
+    self._sleep_patcher = patch('pyrisco.cloud.risco_cloud.asyncio.sleep', new_callable=AsyncMock)
+    self.mock_sleep = self._sleep_patcher.start()
+
+  def tearDown(self):
+    self._sleep_patcher.stop()
+
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._authenticated_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
   async def test_login(self, MockClientSession, mock_authenticated_post):
@@ -405,14 +413,13 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(len(received_events), 1)
     self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + event fetch
 
-  @patch('pyrisco.cloud.risco_cloud.asyncio.sleep', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-  async def test_subscribe_states_calls_error_handler(self, MockClientSession, mock_site_post, mock_sleep):
+  async def test_subscribe_states_calls_error_handler(self, MockClientSession, mock_site_post):
     state_payload = {"partitions": [], "zones": []}
     mock_site_post.return_value = ({"state": {"status": state_payload}}, False)
     # Make sleep raise CancelledError so the loop stops cleanly after the first retry delay
-    mock_sleep.side_effect = asyncio.CancelledError
+    self.mock_sleep.side_effect = asyncio.CancelledError
 
     mock_session = MockClientSession.return_value
     error = RuntimeError("stream broken")
@@ -447,7 +454,7 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
 
     self.assertEqual(len(received_errors), 1)
     self.assertIs(received_errors[0], error)
-    mock_sleep.assert_awaited_once_with(RECONNECT_INITIAL_DELAY)  # first attempt: 1s
+    self.mock_sleep.assert_awaited_once_with(RECONNECT_INITIAL_DELAY)  # first attempt: 1s
 
 
   @patch('pyrisco.cloud.risco_cloud.RiscoCloud._site_post', new_callable=AsyncMock)
@@ -565,9 +572,8 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     self.assertEqual(mock_site_post.call_count, 2)  # initial state fetch + state fetch from SSE, no event fetch
 
 
-  @patch('pyrisco.cloud.risco_cloud.asyncio.sleep', new_callable=AsyncMock)
   @patch('pyrisco.cloud.risco_cloud.aiohttp.ClientSession')
-  async def test_subscribe_states_max_retries_exceeded(self, MockClientSession, mock_sleep):
+  async def test_subscribe_states_max_retries_exceeded(self, MockClientSession):
     """After RECONNECT_MAX_ATTEMPTS failures the loop gives up and notifies via MaxRetriesError."""
     mock_session = MockClientSession.return_value
     error = RuntimeError("connection failed")
@@ -595,9 +601,9 @@ class TestRiscoCloud(unittest.IsolatedAsyncioTestCase):
     self.assertIs(received_errors[-1].last_error, error)
 
     # Sleep called with exponential backoff (no sleep on final attempt)
-    self.assertEqual(mock_sleep.await_count, RECONNECT_MAX_ATTEMPTS - 1)
+    self.assertEqual(self.mock_sleep.await_count, RECONNECT_MAX_ATTEMPTS - 1)
     for i, expected_delay in enumerate([1, 2, 4, 8]):
-      self.assertEqual(mock_sleep.await_args_list[i].args[0], expected_delay)
+      self.assertEqual(self.mock_sleep.await_args_list[i].args[0], expected_delay)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **Fix SSE field casing** — `isOffline` → `IsOffline`, `lastStatusUpdate` → `LastStatusUpdate` so offline guard and deduplication actually work
- **Push-based event log** — SSE messages sometimes include `LastEventUpdated`; when present and newer, `get_events` is called and registered `add_event_handler` callbacks are notified (no more polling required)
- **Initial state on subscribe** — after the SSE connection opens (but before consuming messages), a state fetch is performed so clients always start with current state and can never miss the window between login and first SSE message
- **`LastEventUpdated` independent of `LastStatusUpdate`** — the two update paths are decoupled so a message carrying only `LastEventUpdated` still fires event handlers
- **Auto-reconnect with exponential backoff** — on any connection error the loop retries with delays of 1 s, 2 s, 4 s, 8 s… (capped at 60 s); after `RECONNECT_MAX_ATTEMPTS` (5) consecutive connection failures the error handler is called with `MaxRetriesError` and the loop exits
- **`MaxRetriesError`** — new exception exported from `pyrisco`; wraps the last underlying error so callers can distinguish "still retrying" from "gave up". Recommended response is to schedule a re-login via `asyncio.create_task` (not directly from the error handler, since `close()` awaits the subscription task and would deadlock if called from within it)
- **SSE response status check** — `resp.raise_for_status()` on connect so 4xx/5xx responses go through the backoff/retry path instead of appearing as a clean EOF
- **Minimal delay on clean reconnect** — 1 s delay after a server-side EOF prevents a tight reconnect loop
- **README + example updated** — document backoff behaviour, `MaxRetriesError` handling pattern, `add_event_handler`, and remove the manual reconnect boilerplate

## Test plan

- [ ] `python -m unittest tests/test_risco_cloud.py` — all 18 tests pass
- [ ] Deploy to a live HA instance and confirm SSE reconnects automatically after a network drop
- [ ] Confirm `MaxRetriesError` is raised after 5 consecutive failed connection attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)